### PR TITLE
fix(ci): scope report-summary job off backend working-directory default

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -486,7 +486,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit-tests, integration-tests, reliability-tests, e2e-tests]
     if: always()
-    
+    defaults:
+      run:
+        working-directory: .
+
     steps:
       - name: Download all test results
         uses: actions/download-artifact@v4

--- a/docs/wiki/learned-lessons/github-actions-working-directory-default-only-applies-to-run-steps.md
+++ b/docs/wiki/learned-lessons/github-actions-working-directory-default-only-applies-to-run-steps.md
@@ -1,0 +1,32 @@
+# GitHub Actions `working-directory` default only applies to `run:` steps
+
+A workflow- or job-level `defaults.run.working-directory` override affects **only `run:` steps**
+(shell commands). It has no effect on `uses:` steps (third-party/marketplace actions) — those
+resolve their own working directory internally, ignoring the default entirely.
+
+## Why this matters
+
+In #329, the `report-summary` job in `ci-cd-pipeline.yml` inherited a workflow-level
+`working-directory: backend` default with no checkout step in that job, so `backend/` never
+existed on the runner. The job had two steps:
+
+1. `uses: actions/download-artifact@v4` — **unaffected** by the default, ran fine
+2. `run: echo ... >> $GITHUB_STEP_SUMMARY` — **affected**, failed with
+   `No such file or directory` trying to `cd` into `backend/`
+
+Reading the failure in isolation, it's easy to assume the whole job — including the
+`download-artifact` step — is broken by the missing checkout. It isn't; only `run:` steps are
+sensitive to the default. This matters when picking a fix: overriding `working-directory` at the
+job level (rather than adding a checkout step) is sufficient and correct here specifically because
+the only working-directory-sensitive step doesn't need repo content — it just writes to
+`$GITHUB_STEP_SUMMARY`.
+
+## How to apply
+
+When diagnosing a `working-directory`-related CI failure, check whether the failing step is a
+`run:` or `uses:` step before deciding the fix. A job-level `defaults.run.working-directory`
+override is a minimal, safe fix when: (a) only `run:` steps in that job are affected, and (b) none
+of those steps actually need the directory you're overriding away from.
+
+This generalizes beyond BuildNest — it's a property of GitHub Actions itself, not this repo's
+workflow file.


### PR DESCRIPTION
## Summary
- The `report-summary` job in `ci-cd-pipeline.yml` failed on every run (including `master`) because it inherited the workflow-level `working-directory: backend` default with no checkout step to make that directory exist.
- Added a job-level `defaults.run.working-directory: .` override, scoped only to this job — it doesn't need repo content, it just writes to `$GITHUB_STEP_SUMMARY`.

## Root cause
`defaults.run.working-directory` only affects `run:` steps, not `uses:` steps — so `actions/download-artifact@v4` was unaffected, but the `Generate summary` `run:` step failed trying to `cd` into a nonexistent `backend/`.

Closes #329

## Test plan
- [ ] Confirm `Generate Test Report Summary` job passes on this PR's CI run
- [ ] Confirm no other job's checkout/working-directory behavior changed (override is job-scoped only)