### PR TITLE
fix(ci): set predicate-quantifier: every on paths-filter (#412)

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -45,6 +45,8 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # predicate-quantifier: every is required -- see identical comment in ci.yml.
+          predicate-quantifier: every
           filters: |
             code:
               - '**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # predicate-quantifier: every is required here -- the default ("some")
+          # OR's every pattern in the rule together, so the bare '**' alone would
+          # already match everything regardless of the negations below (confirmed
+          # empirically: code-changed was 'true' for a docs-only PR without this).
+          predicate-quantifier: every
           filters: |
             code:
               - '**'


### PR DESCRIPTION
Follow-up to #414 (merged): the detect-changes job's dorny/paths-filter config still evaluated code-changed=true on a genuinely docs-only PR (#417 caught this — Unit Tests actually ran instead of being skipped). Root cause: dorny/paths-filter defaults to predicate-quantifier: some, which OR's all patterns in a rule together, so the bare '**' base pattern alone already matched everything regardless of the negations. Setting predicate-quantifier: every fixes this.