### PR TITLE
docs: bump README M4 issue count post-#448 closure (183/211)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 16/16 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet | 2026-08-01 | **Complete** (v0.4.0) — 13/13 issues |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 182/209 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 183/211 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 29/72 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
- Re-verifies README's M4 aggregate issue count fresh, post-#448 closure, per this repo's own aggregate-fact-deferred rule (task-list item must stay open until the real current value is verified and restated at closing, not deferred)
- 182/209 -> 183/211 (211 total now includes #448 itself plus the two follow-ups it filed, #535/#536; 183 closed reflects #448's own closure)

## Test plan
- [x] Docs-only change, no code path — count verified via `gh issue list --milestone "M4 — Feature Development" --state all` + jq, not recollection