### PR TITLE
docs: refresh README M4 issue count (190/212, post-#487)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 16/16 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet | 2026-08-01 | **Complete** (v0.4.0) — 13/13 issues |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 189/211 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 190/212 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 29/72 issues closed |
 
 ---


### PR DESCRIPTION
Small follow-up to #544: the M4 count (189/211) was accurate at PR #544's own commit time, but became stale the instant #487 closed and #543 was filed into the same milestone. Re-verified via `gh api .../milestones/4` (closed:190, open:22) and updated the count, per this repo's aggregate-fact-deferred rule requiring the value be re-verified fresh at actual closing time, not left at the plan-time snapshot.

Doc-only change; no code touched.