### PR TITLE
docs: fix README Roadmap table stale milestone counts (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
   bean-validation binding rejects the request before the service is ever called
   (`verifyNoInteractions`).
 
+### Documentation
+- README Roadmap table was badly stale across multiple milestones (#489): M3 was marked
+  **Complete — 13/13** even though 26 issues from a later CheckStyle debt-reduction initiative
+  (epics #371/#376/#380/#387/#391 and their sub-issues, filed 2026-07-13) had been tagged into the
+  M3 milestone afterward without ever updating M3's Roadmap status — root cause confirmed via
+  `gh api .../milestones` plus a listing of M3's 26 open issues, all dated after M3 was originally
+  marked complete. Corrected via the milestone API (not `gh issue list --milestone`, which is known
+  to silently undercount — see
+  `docs/wiki/learned-lessons/gh-issue-list-milestone-undercounts-use-gh-search-issues-instead.md`):
+  M2 16/16 → 17/17, M3 **Complete** → **In progress**, 13/13 → 15/41, M5 29/72 → 52/90. M1 and M4
+  were already accurate and left unchanged.
+
 ### Changed
 - Eliminate `Product.stockQuantity`/`Inventory` dual source of truth (#485, INV-01), follow-up from
   #309: `Product.stockQuantity` is no longer a persisted column — it's now a derived getter reading

--- a/README.md
+++ b/README.md
@@ -282,10 +282,10 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | Milestone | Scope | Target | Status |
 |---|---|---|---|
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
-| M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 16/16 issues |
-| M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet | 2026-08-01 | **Complete** (v0.4.0) — 13/13 issues |
+| M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
+| M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
 | M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 190/212 issues closed |
-| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 29/72 issues closed |
+| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 52/90 issues closed |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes #489: README's Roadmap table had drifted across M2/M3/M5.
- **M3 root cause**: marked **Complete — 13/13**, but 26 open issues from a later CheckStyle debt-reduction initiative (epics #371/#376/#380/#387/#391 and their sub-issues, filed 2026-07-13) were tagged into the M3 milestone after it was originally closed out, with the Roadmap status never updated to reflect it. Confirmed via `gh api .../milestones` + a full listing of M3's 26 open issues (all created 2026-07-13, after M3's original completion).
- Recomputed all 5 rows from `gh api .../milestones` (per `docs/wiki/learned-lessons/gh-issue-list-milestone-undercounts-use-gh-search-issues-instead.md` — `gh issue list --milestone` is known to silently undercount, so the milestone API's own `open_issues`/`closed_issues` fields were used instead):
  - M1: 16/16 — already accurate, unchanged
  - M2: 16/16 → **17/17**
  - M3: **Complete** → **In progress**, 13/13 → **15/41**
  - M4: 190/212 — already accurate, unchanged
  - M5: 29/72 → **52/90**

## update-docs enumeration
- README: updated
- RTM/SRS/SDD/Test-Plan: not applicable — grepped for the stale count strings, no matches; these docs carry no issue-count aggregates
- CHANGELOG: updated (new `### Documentation` entry under Unreleased)
- SDP: checked, not applicable — its M1–M5 references are phase/gate-based (JaCoCo/PIT thresholds, sprint schedule), not issue-count aggregates

## Test plan
- [x] Docs-only change (tier 0 per `testing.md`) — no application code path to unit/integration/E2E test
- [x] Verified via `gh api repos/.../milestones` output matching the corrected table values exactly (pasted above)
- [x] `git diff --cached` read end-to-end pre-commit; only README.md/CHANGELOG.md touched, no unrelated pre-existing working-tree changes swept in

🤖 Generated with [Claude Code](https://claude.com/claude-code)