### PR TITLE
docs: correct M4 count drift caused by #489's own closure (follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,10 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
   marked complete. Corrected via the milestone API (not `gh issue list --milestone`, which is known
   to silently undercount — see
   `docs/wiki/learned-lessons/gh-issue-list-milestone-undercounts-use-gh-search-issues-instead.md`):
-  M2 16/16 → 17/17, M3 **Complete** → **In progress**, 13/13 → 15/41, M5 29/72 → 52/90. M1 and M4
-  were already accurate and left unchanged.
+  M2 16/16 → 17/17, M3 **Complete** → **In progress**, 13/13 → 15/41, M5 29/72 → 52/90. M1 was
+  already accurate and left unchanged. M4's own 190/212 was accurate at the time of the fix but
+  drifted to 191/212 within minutes, since #489's own closure carries the M4 milestone label —
+  corrected in the same closure pass via a small follow-up PR rather than left stale.
 
 ### Changed
 - Eliminate `Product.stockQuantity`/`Inventory` dual source of truth (#485, INV-01), follow-up from

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 190/212 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 191/212 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 52/90 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
- Small follow-up to #489/#546: closure-time re-verification (per `development-workflow.md` step 28) found M4's own count had drifted from 190/212 to 191/212 within minutes of the primary fix landing, because #489 itself carries the M4 milestone label — closing it incremented M4's own closed count.
- Not a new investigation, just a same-session correction of the primary PR's own side effect.

## Test plan
- [x] Docs-only (tier 0), no application code path
- [x] Verified via fresh `gh api .../milestones` output: M1 16/0, M2 17/0, M3 15/26, M4 191/21, M5 52/38 — all now match README exactly