### PR TITLE
feat: seller registration, distinct account type from buyer (#553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
 
 ## [Unreleased] — M4: Feature Development
 
+### Added
+- Seller registration (FR-SEL-01, #553) — the first requirement implemented from the Ph-3
+  marketplace-pivot addendum. An authenticated buyer can register as a seller
+  (`POST /api/user/seller/register`), creating a `Seller` entity (1:1 extension of `User`,
+  mirroring the existing `Address` pattern) and granting `ROLE_SELLER`. `district_id` is
+  implemented as a plain nullable column with no FK constraint — the SDD's planned
+  `Seller ──N:1──► District` FK depends on an unresolved ADR (#561, OQ-01/OQ-02: strict
+  same-district vs. seller-declared-radius matching); registration itself does not require it,
+  so district assignment is deferred to a follow-up once #561 resolves. Added
+  `GET /api/user/seller/profile` and a `DuplicateResourceException` → 409 handler to
+  `GlobalExceptionHandler` (the exception class existed but had no handler before this issue,
+  so a duplicate seller registration would have fallen through to a 500).
+
 ### Fixed
 - Legacy inventory add-stock/update-stock endpoints had no server-side floor validation on
   quantity (#487, discovered during #440): `InventoryServiceImpl.addStock()`/`updateStock()`

--- a/backend/src/main/java/com/example/buildnest_ecommerce/controller/user/SellerController.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/controller/user/SellerController.java
@@ -1,0 +1,54 @@
+package com.example.buildnest_ecommerce.controller.user;
+
+import com.example.buildnest_ecommerce.aspect.Auditable;
+import com.example.buildnest_ecommerce.model.dto.SellerResponseDTO;
+import com.example.buildnest_ecommerce.model.payload.ApiResponse;
+import com.example.buildnest_ecommerce.model.payload.RegisterSellerRequest;
+import com.example.buildnest_ecommerce.security.CustomUserDetails;
+import com.example.buildnest_ecommerce.service.seller.SellerService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Seller registration (FR-SEL-01, #553) — an authenticated user upgrades
+ * their existing buyer account to also be a seller. District assignment is
+ * deferred (see the sellers changeset comment) pending ADR #561.
+ */
+@RestController
+@RequestMapping("/api/user/seller")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('USER')")
+@Tag(name = "Seller", description = "Seller registration and profile")
+@SecurityRequirement(name = "Bearer Authentication")
+public class SellerController {
+
+    private final SellerService sellerService;
+
+    @PostMapping("/register")
+    @Auditable(action = "SELLER_REGISTER", entityType = "SELLER")
+    public ResponseEntity<ApiResponse> registerSeller(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody RegisterSellerRequest request) {
+        SellerResponseDTO seller = sellerService.registerSeller(
+                currentUser.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponse(
+                        true, "Seller registration successful", seller));
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse> getSellerProfile(
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+        SellerResponseDTO seller =
+                sellerService.getSellerProfile(currentUser.getId());
+        return ResponseEntity.ok(
+                new ApiResponse(true, "Seller profile retrieved", seller));
+    }
+}

--- a/backend/src/main/java/com/example/buildnest_ecommerce/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/exception/GlobalExceptionHandler.java
@@ -11,7 +11,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.
+        ResponseEntityExceptionHandler;
 
 @Slf4j
 @RestControllerAdvice
@@ -27,10 +28,25 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 ex.getMessage(),
                 "Resource not found"
         );
-        errorResponse.setPath(request.getDescription(false).replace("uri=", ""));
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
     
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateResourceException(
+            DuplicateResourceException ex, WebRequest request) {
+        log.warn("Duplicate resource: {}", ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.CONFLICT.value(),
+                ex.getMessage(),
+                "Duplicate resource"
+        );
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
+        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+    }
+
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(
             ValidationException ex, WebRequest request) {
@@ -40,7 +56,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 ex.getMessage(),
                 "Validation failed"
         );
-        errorResponse.setPath(request.getDescription(false).replace("uri=", ""));
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
@@ -53,20 +70,25 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 ex.getMessage(),
                 "Access denied"
         );
-        errorResponse.setPath(request.getDescription(false).replace("uri=", ""));
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
 
-    @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleSpringSecurityAccessDeniedException(
-            org.springframework.security.access.AccessDeniedException ex, WebRequest request) {
+    @ExceptionHandler(
+            org.springframework.security.access.AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse>
+            handleSpringSecurityAccessDeniedException(
+            org.springframework.security.access.AccessDeniedException ex,
+            WebRequest request) {
         log.warn("Authorization denied: {}", ex.getMessage());
         ErrorResponse errorResponse = new ErrorResponse(
                 HttpStatus.FORBIDDEN.value(),
                 "You do not have permission to perform this action",
                 "Access denied"
         );
-        errorResponse.setPath(request.getDescription(false).replace("uri=", ""));
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
     
@@ -79,7 +101,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 ex.getMessage(),
                 "Payment processing failed"
         );
-        errorResponse.setPath(request.getDescription(false).replace("uri=", ""));
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
@@ -92,7 +115,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 ex.getMessage(),
                 "Invalid argument"
         );
-        errorResponse.setPath(request.getDescription(false).replace("uri=", ""));
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
@@ -128,7 +152,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 message,
                 "Validation failed"
         );
-        errorResponse.setPath(request.getDescription(false).replace("uri=", ""));
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
 
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
@@ -142,7 +167,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 "An unexpected error occurred",
                 ex.getMessage()
         );
-        errorResponse.setPath(request.getDescription(false).replace("uri=", ""));
-        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+        errorResponse.setPath(
+                request.getDescription(false).replace("uri=", ""));
+        return new ResponseEntity<>(
+                errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/backend/src/main/java/com/example/buildnest_ecommerce/model/dto/SellerResponseDTO.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/model/dto/SellerResponseDTO.java
@@ -1,0 +1,23 @@
+package com.example.buildnest_ecommerce.model.dto;
+
+import com.example.buildnest_ecommerce.model.entity.Seller;
+import java.time.LocalDateTime;
+
+public record SellerResponseDTO(
+        Long id,
+        Long userId,
+        String businessName,
+        String businessRegistrationNumber,
+        Seller.VerificationStatus verificationStatus,
+        LocalDateTime createdAt) {
+
+    public static SellerResponseDTO from(Seller seller) {
+        return new SellerResponseDTO(
+                seller.getId(),
+                seller.getUser().getId(),
+                seller.getBusinessName(),
+                seller.getBusinessRegistrationNumber(),
+                seller.getVerificationStatus(),
+                seller.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/example/buildnest_ecommerce/model/entity/Seller.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/model/entity/Seller.java
@@ -1,0 +1,59 @@
+package com.example.buildnest_ecommerce.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import java.time.LocalDateTime;
+
+/**
+ * Seller — 1:1 extension of {@link User}, mirroring the existing
+ * {@link Address} extension-table pattern (SDD v4.0 §4.3.3/§4.5.1/§4.5.2).
+ * {@code districtId} is deliberately a plain nullable column, not a mapped
+ * FK/association — the District entity itself is blocked on ADR #561
+ * (OQ-01/OQ-02); assigning it happens once that resolves.
+ */
+@Entity
+@Table(name = "sellers")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(exclude = { "user", "createdAt", "updatedAt" })
+@ToString(exclude = { "user" })
+public class Seller implements AggregateRoot {
+
+    public enum VerificationStatus {
+        PENDING, VERIFIED, REJECTED
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "business_name", nullable = false)
+    private String businessName;
+
+    @Column(name = "business_registration_number")
+    private String businessRegistrationNumber;
+
+    @Column(name = "district_id")
+    private Long districtId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "verification_status", nullable = false)
+    private VerificationStatus verificationStatus = VerificationStatus.PENDING;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/example/buildnest_ecommerce/model/payload/RegisterSellerRequest.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/model/payload/RegisterSellerRequest.java
@@ -1,0 +1,20 @@
+package com.example.buildnest_ecommerce.model.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterSellerRequest {
+
+    @NotBlank(message = "Business name is required")
+    @Size(max = 255, message = "Business name must be at most 255 characters")
+    private String businessName;
+
+    @Size(max = 100, message = "Registration number must be at most 100 chars")
+    private String businessRegistrationNumber;
+}

--- a/backend/src/main/java/com/example/buildnest_ecommerce/repository/SellerRepository.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/repository/SellerRepository.java
@@ -1,0 +1,14 @@
+package com.example.buildnest_ecommerce.repository;
+
+import com.example.buildnest_ecommerce.model.entity.Seller;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SellerRepository extends JpaRepository<Seller, Long> {
+    Optional<Seller> findByUser_Id(Long userId);
+
+    boolean existsByUser_Id(Long userId);
+}

--- a/backend/src/main/java/com/example/buildnest_ecommerce/service/seller/SellerService.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/service/seller/SellerService.java
@@ -1,0 +1,11 @@
+package com.example.buildnest_ecommerce.service.seller;
+
+import com.example.buildnest_ecommerce.model.dto.SellerResponseDTO;
+import com.example.buildnest_ecommerce.model.payload.RegisterSellerRequest;
+
+public interface SellerService {
+    SellerResponseDTO registerSeller(
+            Long userId, RegisterSellerRequest request);
+
+    SellerResponseDTO getSellerProfile(Long userId);
+}

--- a/backend/src/main/java/com/example/buildnest_ecommerce/service/seller/SellerServiceImpl.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/service/seller/SellerServiceImpl.java
@@ -1,0 +1,96 @@
+package com.example.buildnest_ecommerce.service.seller;
+
+import com.example.buildnest_ecommerce.exception.DuplicateResourceException;
+import com.example.buildnest_ecommerce.exception.ResourceNotFoundException;
+import com.example.buildnest_ecommerce.model.dto.SellerResponseDTO;
+import com.example.buildnest_ecommerce.model.entity.Role;
+import com.example.buildnest_ecommerce.model.entity.Seller;
+import com.example.buildnest_ecommerce.model.entity.User;
+import com.example.buildnest_ecommerce.model.payload.RegisterSellerRequest;
+import com.example.buildnest_ecommerce.repository.RoleRepository;
+import com.example.buildnest_ecommerce.repository.SellerRepository;
+import com.example.buildnest_ecommerce.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Seller registration — creates the 1:1 {@link Seller} extension of an
+ * existing {@link User} account and grants {@code ROLE_SELLER}, following
+ * the get-or-create role pattern already used by
+ * {@code AuthServiceImpl.register}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SellerServiceImpl implements SellerService {
+
+    private static final String ROLE_SELLER = "ROLE_SELLER";
+
+    private final SellerRepository sellerRepository;
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+
+    @Override
+    @Transactional
+    public SellerResponseDTO registerSeller(
+            Long userId, RegisterSellerRequest request) {
+        log.info("Seller registration attempt for user: {}", userId);
+
+        if (sellerRepository.existsByUser_Id(userId)) {
+            throw new DuplicateResourceException(
+                    "Seller", "userId", String.valueOf(userId));
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(
+                        () -> new ResourceNotFoundException("User", userId));
+
+        Seller seller = new Seller();
+        seller.setUser(user);
+        seller.setBusinessName(request.getBusinessName());
+        seller.setBusinessRegistrationNumber(
+                request.getBusinessRegistrationNumber());
+        seller.setVerificationStatus(Seller.VerificationStatus.PENDING);
+        seller.setCreatedAt(LocalDateTime.now());
+
+        Seller saved = sellerRepository.save(seller);
+
+        grantSellerRole(user);
+
+        return SellerResponseDTO.from(saved);
+    }
+
+    @Override
+    public SellerResponseDTO getSellerProfile(Long userId) {
+        Seller seller = sellerRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Seller profile not found for user: " + userId));
+        return SellerResponseDTO.from(seller);
+    }
+
+    private void grantSellerRole(User user) {
+        Role sellerRole = roleRepository.findByName(ROLE_SELLER)
+                .orElseGet(() -> {
+                    Role role = new Role();
+                    role.setName(ROLE_SELLER);
+                    role.setDescription(
+                            "Seller account — owns a product catalogue");
+                    return roleRepository.save(role);
+                });
+
+        Set<Role> roles = user.getRoles() == null
+                ? new HashSet<>()
+                : new HashSet<>(user.getRoles());
+        roles.add(sellerRole);
+        user.setRoles(roles);
+        user.setUpdatedAt(LocalDateTime.now());
+        userRepository.save(user);
+    }
+}

--- a/backend/src/main/resources/db/changelog/changes/20260722-024-create-sellers.xml
+++ b/backend/src/main/resources/db/changelog/changes/20260722-024-create-sellers.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <!-- Issue #553 (FR-SEL-01): Seller registration — a Seller is a 1:1
+         extension of User, mirroring the existing Address pattern (SDD v4.0
+         §4.3.3/§4.5.1/§4.5.2). district_id is deliberately a plain nullable
+         BIGINT with no FK constraint yet: the District entity/table itself
+         is blocked on an unresolved ADR (#561, OQ-01/OQ-02 — strict
+         same-district vs. seller-declared-radius matching changes whether
+         this becomes a single FK or an N:M join table). Assigning the
+         district comes later, once #561/#562 resolve — registration itself
+         does not require it. -->
+    <changeSet id="20260722-024-create-sellers" author="buildnest-team">
+        <comment>Create sellers table (FR-SEL-01, #553) — 1:1 extension of users, district_id deferred pending ADR #561</comment>
+
+        <createTable tableName="sellers">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false" unique="true" uniqueConstraintName="uk_sellers_user_id"/>
+            </column>
+            <column name="business_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="business_registration_number" type="VARCHAR(100)"/>
+            <column name="district_id" type="BIGINT"/>
+            <column name="verification_status" type="VARCHAR(30)" defaultValue="PENDING">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP"/>
+        </createTable>
+
+        <addForeignKeyConstraint
+            constraintName="fk_sellers_user"
+            baseTableName="sellers" baseColumnNames="user_id"
+            referencedTableName="users" referencedColumnNames="id"
+            onDelete="CASCADE"/>
+
+        <createIndex indexName="idx_sellers_verification_status" tableName="sellers">
+            <column name="verification_status"/>
+        </createIndex>
+
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="sellers" constraintName="fk_sellers_user"/>
+            <dropTable tableName="sellers"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/backend/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.xml
@@ -32,5 +32,6 @@
     <include file="db/changelog/changes/20260718-021-backfill-inventory-for-products.xml" relativeToChangelogFile="false"/>
     <include file="db/changelog/changes/20260719-022-reconcile-coupons-schema.xml" relativeToChangelogFile="false"/>
     <include file="db/changelog/changes/20260721-023-drop-product-stock-quantity.xml" relativeToChangelogFile="false"/>
+    <include file="db/changelog/changes/20260722-024-create-sellers.xml" relativeToChangelogFile="false"/>
 
 </databaseChangeLog>

--- a/backend/src/test/java/com/example/buildnest_ecommerce/controller/user/SellerControllerTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/controller/user/SellerControllerTest.java
@@ -1,0 +1,56 @@
+package com.example.buildnest_ecommerce.controller.user;
+
+import com.example.buildnest_ecommerce.model.dto.SellerResponseDTO;
+import com.example.buildnest_ecommerce.model.entity.Seller;
+import com.example.buildnest_ecommerce.model.payload.RegisterSellerRequest;
+import com.example.buildnest_ecommerce.security.CustomUserDetails;
+import com.example.buildnest_ecommerce.service.seller.SellerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SellerControllerTest {
+
+    private static CustomUserDetails userDetails(Long id) {
+        return new CustomUserDetails(id, "shopowner", "s@example.com",
+                "hash", Collections.emptyList(), true, true, true, true);
+    }
+
+    @Test
+    void registerSeller_returnsCreatedWithBody() {
+        SellerService sellerService = mock(SellerService.class);
+        RegisterSellerRequest request =
+                new RegisterSellerRequest("Acme Décor", "REG-1");
+        SellerResponseDTO dto = new SellerResponseDTO(10L, 3L, "Acme Décor",
+                "REG-1", Seller.VerificationStatus.PENDING,
+                LocalDateTime.now());
+        when(sellerService.registerSeller(3L, request)).thenReturn(dto);
+
+        SellerController controller = new SellerController(sellerService);
+        ResponseEntity<?> response =
+                controller.registerSeller(userDetails(3L), request);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    }
+
+    @Test
+    void getSellerProfile_returnsOkWithBody() {
+        SellerService sellerService = mock(SellerService.class);
+        SellerResponseDTO dto = new SellerResponseDTO(10L, 3L, "Acme Décor",
+                null, Seller.VerificationStatus.PENDING, LocalDateTime.now());
+        when(sellerService.getSellerProfile(3L)).thenReturn(dto);
+
+        SellerController controller = new SellerController(sellerService);
+        ResponseEntity<?> response =
+                controller.getSellerProfile(userDetails(3L));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+}

--- a/backend/src/test/java/com/example/buildnest_ecommerce/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/exception/GlobalExceptionHandlerTest.java
@@ -200,6 +200,32 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    @DisplayName("Should handle DuplicateResourceException correctly")
+    void testHandleDuplicateResourceException() {
+        // Arrange
+        DuplicateResourceException exception =
+                new DuplicateResourceException("Seller", "userId", "3");
+
+        // Act
+        ResponseEntity<ErrorResponse> response =
+                exceptionHandler.handleDuplicateResourceException(
+                        exception, webRequest);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+
+        ErrorResponse errorResponse = response.getBody();
+        assertNotNull(errorResponse);
+        assertEquals(409, errorResponse.getStatusCode());
+        assertEquals(
+                "Seller with userId '3' already exists",
+                errorResponse.getMessage());
+        assertEquals("Duplicate resource", errorResponse.getError());
+        assertEquals("/api/test", errorResponse.getPath());
+    }
+
+    @Test
     @DisplayName("Should handle ValidationException correctly")
     void testHandleValidationException() {
         // Arrange

--- a/backend/src/test/java/com/example/buildnest_ecommerce/service/seller/SellerRegistrationIT.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/service/seller/SellerRegistrationIT.java
@@ -1,0 +1,92 @@
+package com.example.buildnest_ecommerce.service.seller;
+
+import com.example.buildnest_ecommerce.CivilEcommerceApplication;
+import com.example.buildnest_ecommerce.config.TestSecurityConfig;
+import com.example.buildnest_ecommerce.exception.DuplicateResourceException;
+import com.example.buildnest_ecommerce.model.dto.SellerResponseDTO;
+import com.example.buildnest_ecommerce.model.entity.Seller;
+import com.example.buildnest_ecommerce.model.entity.User;
+import com.example.buildnest_ecommerce.model.payload.RegisterSellerRequest;
+import com.example.buildnest_ecommerce.repository.SellerRepository;
+import com.example.buildnest_ecommerce.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Real-persistence regression test for #553 (FR-SEL-01) — proves the
+ * Liquibase {@code sellers} changeset, the entity mapping, and the
+ * {@code ROLE_SELLER} grant actually round-trip through H2, not just that
+ * mocked repositories were called with the right arguments (see
+ * service-layer-mocked-unit-tests-can-fully-cover... in the wiki lessons).
+ */
+@SpringBootTest(classes = CivilEcommerceApplication.class)
+@ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
+@Transactional
+class SellerRegistrationIT {
+
+    @Autowired
+    private SellerService sellerService;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setUsername("it-shopowner-" + System.nanoTime());
+        user.setEmail("it-shopowner-" + System.nanoTime() + "@example.com");
+        user.setPassword("hash");
+        user.setIsActive(true);
+        user.setIsDeleted(false);
+        user.setCreatedAt(LocalDateTime.now());
+        user = userRepository.save(user);
+    }
+
+    @Test
+    void registerSeller_persistsSellerAndGrantsRole() {
+        RegisterSellerRequest request =
+                new RegisterSellerRequest("Acme Décor", "REG-1");
+
+        SellerResponseDTO result =
+                sellerService.registerSeller(user.getId(), request);
+
+        assertThat(result.id()).isNotNull();
+        Seller persisted = sellerRepository.findByUser_Id(user.getId())
+                .orElseThrow();
+        assertThat(persisted.getBusinessName()).isEqualTo("Acme Décor");
+        assertThat(persisted.getVerificationStatus())
+                .isEqualTo(Seller.VerificationStatus.PENDING);
+        assertThat(persisted.getDistrictId()).isNull();
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(reloaded.getRoles())
+                .anyMatch(r -> "ROLE_SELLER".equals(r.getName()));
+    }
+
+    @Test
+    void registerSeller_calledTwiceForSameUser_throwsDuplicate() {
+        RegisterSellerRequest request =
+                new RegisterSellerRequest("Acme Décor", null);
+        sellerService.registerSeller(user.getId(), request);
+
+        assertThatThrownBy(
+                () -> sellerService.registerSeller(user.getId(), request))
+                .isInstanceOf(DuplicateResourceException.class);
+    }
+}

--- a/backend/src/test/java/com/example/buildnest_ecommerce/service/seller/SellerServiceImplTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/service/seller/SellerServiceImplTest.java
@@ -1,0 +1,154 @@
+package com.example.buildnest_ecommerce.service.seller;
+
+import com.example.buildnest_ecommerce.exception.DuplicateResourceException;
+import com.example.buildnest_ecommerce.exception.ResourceNotFoundException;
+import com.example.buildnest_ecommerce.model.dto.SellerResponseDTO;
+import com.example.buildnest_ecommerce.model.entity.Role;
+import com.example.buildnest_ecommerce.model.entity.Seller;
+import com.example.buildnest_ecommerce.model.entity.User;
+import com.example.buildnest_ecommerce.model.payload.RegisterSellerRequest;
+import com.example.buildnest_ecommerce.repository.RoleRepository;
+import com.example.buildnest_ecommerce.repository.SellerRepository;
+import com.example.buildnest_ecommerce.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SellerServiceImplTest {
+
+    @Mock
+    private SellerRepository sellerRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RoleRepository roleRepository;
+
+    private SellerServiceImpl sellerService;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        sellerService = new SellerServiceImpl(
+                sellerRepository, userRepository, roleRepository);
+        user = new User();
+        user.setId(3L);
+        user.setUsername("shopowner");
+        user.setRoles(new HashSet<>());
+    }
+
+    @Test
+    void registerSeller_newUser_createsSellerAndGrantsRole() {
+        RegisterSellerRequest request =
+                new RegisterSellerRequest("Acme Décor", "REG-123");
+        when(sellerRepository.existsByUser_Id(3L)).thenReturn(false);
+        when(userRepository.findById(3L)).thenReturn(Optional.of(user));
+        when(sellerRepository.save(any(Seller.class)))
+                .thenAnswer(inv -> {
+                    Seller s = inv.getArgument(0);
+                    s.setId(10L);
+                    return s;
+                });
+        Role sellerRole = new Role();
+        sellerRole.setName("ROLE_SELLER");
+        when(roleRepository.findByName("ROLE_SELLER"))
+                .thenReturn(Optional.of(sellerRole));
+
+        SellerResponseDTO result =
+                sellerService.registerSeller(3L, request);
+
+        assertThat(result.id()).isEqualTo(10L);
+        assertThat(result.businessName()).isEqualTo("Acme Décor");
+        assertThat(result.verificationStatus())
+                .isEqualTo(Seller.VerificationStatus.PENDING);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        Set<Role> savedRoles = userCaptor.getValue().getRoles();
+        assertThat(savedRoles).contains(sellerRole);
+    }
+
+    @Test
+    void registerSeller_userWithNullRoles_doesNotThrow() {
+        // Regression test: a User whose roles collection was never
+        // explicitly initialized (getRoles() == null) previously NPE'd in
+        // grantSellerRole — caught by SellerRegistrationIT's real
+        // persistence, invisible to the other unit tests above since they
+        // all pre-set an empty HashSet.
+        user.setRoles(null);
+        RegisterSellerRequest request =
+                new RegisterSellerRequest("Acme Décor", null);
+        when(sellerRepository.existsByUser_Id(3L)).thenReturn(false);
+        when(userRepository.findById(3L)).thenReturn(Optional.of(user));
+        when(sellerRepository.save(any(Seller.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        Role sellerRole = new Role();
+        sellerRole.setName("ROLE_SELLER");
+        when(roleRepository.findByName("ROLE_SELLER"))
+                .thenReturn(Optional.of(sellerRole));
+
+        sellerService.registerSeller(3L, request);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getRoles()).contains(sellerRole);
+    }
+
+    @Test
+    void registerSeller_alreadySeller_throwsDuplicateResourceException() {
+        RegisterSellerRequest request =
+                new RegisterSellerRequest("Acme Décor", null);
+        when(sellerRepository.existsByUser_Id(3L)).thenReturn(true);
+
+        assertThatThrownBy(() -> sellerService.registerSeller(3L, request))
+                .isInstanceOf(DuplicateResourceException.class);
+    }
+
+    @Test
+    void registerSeller_unknownUser_throwsResourceNotFoundException() {
+        RegisterSellerRequest request =
+                new RegisterSellerRequest("Acme Décor", null);
+        when(sellerRepository.existsByUser_Id(99L)).thenReturn(false);
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sellerService.registerSeller(99L, request))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void getSellerProfile_existingSeller_returnsDto() {
+        Seller seller = new Seller();
+        seller.setId(10L);
+        seller.setUser(user);
+        seller.setBusinessName("Acme Décor");
+        seller.setVerificationStatus(Seller.VerificationStatus.VERIFIED);
+        when(sellerRepository.findByUser_Id(3L))
+                .thenReturn(Optional.of(seller));
+
+        SellerResponseDTO result = sellerService.getSellerProfile(3L);
+
+        assertThat(result.verificationStatus())
+                .isEqualTo(Seller.VerificationStatus.VERIFIED);
+    }
+
+    @Test
+    void getSellerProfile_noSeller_throwsResourceNotFoundException() {
+        when(sellerRepository.findByUser_Id(3L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sellerService.getSellerProfile(3L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/example/buildnest_ecommerce/service/seller/SellerServiceImplTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/service/seller/SellerServiceImplTest.java
@@ -72,13 +72,54 @@ class SellerServiceImplTest {
 
         assertThat(result.id()).isEqualTo(10L);
         assertThat(result.businessName()).isEqualTo("Acme Décor");
+        assertThat(result.businessRegistrationNumber())
+                .isEqualTo("REG-123");
         assertThat(result.verificationStatus())
                 .isEqualTo(Seller.VerificationStatus.PENDING);
+        assertThat(result.createdAt()).isNotNull();
+
+        ArgumentCaptor<Seller> sellerCaptor =
+                ArgumentCaptor.forClass(Seller.class);
+        verify(sellerRepository).save(sellerCaptor.capture());
+        assertThat(sellerCaptor.getValue().getBusinessRegistrationNumber())
+                .isEqualTo("REG-123");
+        assertThat(sellerCaptor.getValue().getVerificationStatus())
+                .isEqualTo(Seller.VerificationStatus.PENDING);
+        assertThat(sellerCaptor.getValue().getCreatedAt()).isNotNull();
 
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(userCaptor.capture());
         Set<Role> savedRoles = userCaptor.getValue().getRoles();
         assertThat(savedRoles).contains(sellerRole);
+        assertThat(userCaptor.getValue().getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void registerSeller_roleDoesNotExistYet_createsAndGrantsNewRole() {
+        RegisterSellerRequest request =
+                new RegisterSellerRequest("Acme Décor", null);
+        when(sellerRepository.existsByUser_Id(3L)).thenReturn(false);
+        when(userRepository.findById(3L)).thenReturn(Optional.of(user));
+        when(sellerRepository.save(any(Seller.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(roleRepository.findByName("ROLE_SELLER"))
+                .thenReturn(Optional.empty());
+        when(roleRepository.save(any(Role.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        sellerService.registerSeller(3L, request);
+
+        ArgumentCaptor<Role> roleCaptor = ArgumentCaptor.forClass(Role.class);
+        verify(roleRepository).save(roleCaptor.capture());
+        assertThat(roleCaptor.getValue().getName()).isEqualTo("ROLE_SELLER");
+        assertThat(roleCaptor.getValue().getDescription())
+                .isEqualTo("Seller account — owns a product catalogue");
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getRoles())
+                .extracting(Role::getName)
+                .contains("ROLE_SELLER");
     }
 
     @Test

--- a/docs/SDLC-docs/design/software-design-description.md
+++ b/docs/SDLC-docs/design/software-design-description.md
@@ -10,12 +10,12 @@
 | :--- | :--- |
 | **Document Title** | Software Design Description (SDD) |
 | **Document ID** | SDD-BUILDNEST-001 |
-| **Version** | 3.8 |
+| **Version** | 4.1 |
 | **Date** | 2026-07-22 IST |
 | **Status** | Controlled — Under Review |
 | **Classification** | Internal Use |
 | **Conformance Standard** | ISO/IEC/IEEE 1016:2017 |
-| **Related SRS** | SRS-BUILDNEST-001 v4.9 (docs/SDLC-docs/requirement-engineering/software-requirements-specification.md) |
+| **Related SRS** | SRS-BUILDNEST-001 v5.1 (docs/SDLC-docs/requirement-engineering/software-requirements-specification.md) |
 | **Supersedes** | SDD v2.0 (archive/docs/ISO-IEC-IEEE/SDD_IEEE_1016_2017.md, 2026-02-11) |
 
 ---
@@ -35,6 +35,8 @@
 | 3.4 | 2026-07-17 20:45 IST | Software Architect | Full re-derivation of §4.7.3's API Endpoint Catalogue (#471), same staleness class already fixed in SRS Appendix A (#456): 7 stale sections (wrong path prefixes — `/api/auth/refresh-token` instead of real `/api/auth/refresh`, `/api/auth/forgot-password`/`reset-password` instead of real `/api/password/forgot`/`reset`; only legacy `/api/checkout/*`, missing the current `/api/v1/checkout/*` multi-step flow entirely) expanded to 36 groups, each citing its real controller class. Unlike Appendix A, this table also carries a Rate Limit column per row — verified directly against `RateLimitHeaderInterceptor`/`AdminRateLimitFilter`/`RateLimitUtil` source and `application.properties`, surfacing a previously-undocumented gap: `/api/v1/admin/**` (base path for most admin resource controllers — products, categories, tags, coupons, shipping-methods, search, orders, inventory, sales analytics) matches neither the interceptor's nor the filter's literal `/api/admin/` prefix check, so those endpoints receive only the 100/min default header and no dedicated admin-tier blocking, unlike the literal `/api/admin/**` groups (users, analytics, audit, webhooks, monitoring, thresholds, inventory-threshold/analytics/reports) which get 30/min headers + a real 50/min block | Pending |
 | 3.5 | 2026-07-17 21:15 IST | Software Architect | Found during a fresh RTM/SRS/SDD/Test-Plan verification sweep: `Related SRS` had drifted one version behind again (v4.4, SRS is now v4.5 following #474) — the same recurring cross-reference-currency gap already fixed twice before at 3.3/3.4. Updated to current | Pending |
 | 3.6 | 2026-07-19 10:40 IST | Software Architect | §4.7.3's checkout endpoint catalogue row for `POST /api/v1/checkout/coupon` cited the wrong SRS requirement (`FR-CHK-02`, "calculate checkout total") — corrected to the newly-added `FR-CHK-09` (apply coupon during checkout, #436), which had never existed as a row until this issue added it to both SRS and RTM. Updated `Related SRS` from v4.5 to v4.9 (only the one edge this change directly touches — a full cross-reference-mesh sweep is the periodic 15-issue sync's job, not a per-issue one) | Pending |
+| 4.0 | 2026-07-22 15:30 IST | Software Architect | **Marketplace pivot addendum**, design counterpart to SRS v5.0's FG-11/FG-12 addendum (FR-SEL-*/FR-LOC-*). Added planned entity design for `Seller` and `District` (§4.3.3, §4.5.1, §4.5.2) and a Location-Based Matching design sketch (new §4.5.6). **Notable finding during existing-system assessment**: the original bootstrap schema (`db.changelog-master.sql`, pre-004 changeset) already has a dormant `supplier_id BIGINT` column + `fk_product_supplier` FK on `product` → `users(id)`, never mapped onto the `Product` JPA entity or referenced by any service/repository code (confirmed via full-source grep — the only other `supplier` hits are an excluded-fields code comment and unrelated `ThrowableSupplier` functional-interface usages). §4.5.2's existing row claiming `Product` has `FK → supplier_id (users)` as an active constraint was itself stale/misleading — corrected to note it as legacy and unmapped. Design recommendation: reactivate and repurpose this existing FK for seller ownership (FR-SEL-03) rather than adding a redundant parallel column, once the `District`/`Seller` entity split below is finalised. All new content is explicitly Ph-3/Planned — no code changed in this revision; `Related SRS` updated 4.9 → 5.0 | Pending |
+| 4.1 | 2026-07-22 17:30 IST | Software Architect | §4.5.2's `Seller` row updated from *(Ph-3, Planned)* to reflect real implementation (#553): the entity/Liquibase changeset/service/controller exist now. `district_id` was implemented as a plain nullable column with no FK constraint — the FK's actual shape (single vs. N:M) is still blocked on ADR #561 (OQ-01/OQ-02), unchanged from v4.0's sketch; only the deferral decision itself is newly documented here | Pending |
 | 3.7 | 2026-07-21 IST | Software Architect | Added a Dead-Code Audit Decision Record to §4.7.3 (#448) for four zero-frontend-caller endpoint groups (`ProductControllerV1`, `ProductControllerV2`, legacy `CheckoutController`, `/auth/validate-token`) — audited each against `frontend/src/api/{products,checkout}.ts` and `ApiSunsetInterceptor` directly; none removed on this pass (product-scope calls about unbuilt external/mobile consumers, not code-cleanup calls). Surfaced and filed as follow-ups: #535 (V2/`HomeController` "Current"/"Legacy" label contradiction — V2 is labeled current but carries zero traffic) and #536 (revisit V1 removal once its 2026-12-31 sunset passes) | Pending |
 | 3.8 | 2026-07-22 IST | Software Architect | §5.2.1's Exception-to-HTTP Mapping table was missing `ConstraintViolationException` (400/`VALIDATION_ERROR`) — added as part of #487's fix (`AdminInventoryController`'s `add-stock`/`update-stock` `@RequestParam Integer quantity` gained `@Min(0)` + `@Validated`, which throws this exception type; `GlobalExceptionHandler` needed its own new handler for it, not previously required since no `@RequestParam`/`@PathVariable` constraint existed anywhere in the codebase before this fix) | Pending |
 
@@ -421,6 +423,11 @@ JPA Entity Hierarchy:
   User ──[1:N]──► ProductReview ──[N:1]──► Product
   User ──[1:N]──► Wishlist
   Inventory ──[1:N]──► InventoryThresholdBreachEvent
+
+Planned (Ph-3, SRS FG-11/FG-12 — not yet implemented):
+  User ──[0..1:1]──► Seller ──[N:1]──► District
+  Seller ──[1:N]──► Product   (reactivates legacy product.supplier_id FK, see §4.5.2)
+  User ──[N:1]──► District   (buyer's own district, derived from Address)
 ```
 
 **Fetch Type Decisions**:
@@ -556,6 +563,15 @@ User ──[1:1]──── Cart
  └──[1:N]──── Wishlist
 
 WebhookSubscription  (standalone — no User FK)
+
+Planned (Ph-3, SRS FG-11/FG-12 — not yet implemented, design sketch only):
+Seller ──[1:1]──── User (extension table, mirrors the existing Address pattern)
+   │
+   ├──[N:1]──── District
+   └──[1:N]──── Product  (reactivates product.supplier_id, see §4.5.2 note above)
+
+District  (admin-maintained reference table — see §4.5.6 for the open sourcing/matching questions)
+   └──[1:N]──── User  (buyer's district, likely derived from Address rather than a direct FK — TBD)
 ```
 
 #### 4.5.2 Core Entity Details
@@ -565,7 +581,7 @@ WebhookSubscription  (standalone — no User FK)
 | `User` | `users` | `id BIGINT AUTO_INCREMENT` | `email` UNIQUE, `username` UNIQUE |
 | `Role` | `roles` | `id BIGINT AUTO_INCREMENT` | `name` UNIQUE (`USER`, `ADMIN`) |
 | `Permission` | `permissions` | `id BIGINT AUTO_INCREMENT` | `name` UNIQUE |
-| `Product` | `product` | `id BIGINT AUTO_INCREMENT` | FK → `category`, FK → `supplier_id` (users) |
+| `Product` | `product` | `id BIGINT AUTO_INCREMENT` | FK → `category`. Also has a legacy, **unmapped** `supplier_id` column + `fk_product_supplier` FK → `users` from the original bootstrap schema — present in the database, absent from the `Product` JPA entity and all service code (see Revision History v4.0). Not an active constraint today; a candidate for reactivation as the seller-ownership FK (§4.5.2 `Seller`/`District`, Ph-3) |
 | `Category` | `category` | `id BIGINT AUTO_INCREMENT` | `name` UNIQUE |
 | `Cart` | `cart` | `id BIGINT AUTO_INCREMENT` | FK → `user_id` (one-to-one) |
 | `CartItem` | `cart_item` | `id BIGINT AUTO_INCREMENT` | FK → `cart_id`, FK → `product_id` |
@@ -581,6 +597,8 @@ WebhookSubscription  (standalone — no User FK)
 | `Address` | `addresses` | `id BIGINT AUTO_INCREMENT` | FK → `user_id` |
 | `WebhookSubscription` | `webhook_subscription` | `id BIGINT AUTO_INCREMENT` | `event_type`, `target_url` |
 | `InventoryThresholdBreachEvent` | `inventory_threshold_breach_events` | `id BIGINT AUTO_INCREMENT` | FK → `inventory_id` |
+| `Seller` *(#553, registration implemented)* | `sellers` | `id BIGINT AUTO_INCREMENT` | FK → `user_id` (one-to-one, mirrors `Address`'s extension-table pattern), `district_id` implemented as a plain nullable column with no FK constraint yet (deferred pending ADR #561/OQ-01/OQ-02), verification-status column (FR-SEL-02, still Planned) |
+| `District` *(Ph-3, Planned)* | `districts` | `id BIGINT AUTO_INCREMENT` | `name` UNIQUE (assumes an admin-maintained reference table — see §4.5.6 OQ-02) |
 
 #### 4.5.3 Data Flow — Order Placement with Payment
 
@@ -628,6 +646,22 @@ WebhookSubscription  (standalone — no User FK)
 There is no Redux, React Query, or SWR in the dependency tree — all client state is either the one
 `AuthContext` Provider or hook-local component state, per the project's own `react/coding-style.md`
 guidance ("Context for cross-cutting state... not for high-frequency updates").
+
+---
+
+#### 4.5.6 Location-Based Matching — Design Sketch (Ph-3, Planned)
+
+**Status**: Design sketch only, deliberately incomplete pending two open decisions carried over from SRS §3.2.12 (OQ-01, OQ-02). Nothing below is implemented; no entity, migration, or query described here exists in the codebase.
+
+**Candidate query strategy** (assuming OQ-01 resolves to strict same-district matching, the simpler of the two options): filter the existing Elasticsearch-backed product search (FG-02) by an added `districtId` field on `ProductDocument`, populated from the owning `Seller.district` at index time via the existing event-driven sync flow (`ProductIndexEventListener`, per `spring/elasticsearch.md`) — the buyer's own `districtId` (resolved from their `Address`) becomes a mandatory filter clause alongside the existing `isActive: true` filter, following the same pattern already used for soft-delete exclusion.
+
+**If OQ-01 instead resolves to radius/seller-declared delivery districts** (a seller serves N districts, not just their home one), this becomes a `Seller ──[N:M]──► District` join table instead of a single FK, and the ES filter becomes a `terms` query against the seller's declared district list rather than an exact match — a materially different design, which is why this decision needs to be made (`solution-options-adr`) before either the entity model above or this query strategy is finalised.
+
+**Why Elasticsearch, not a JPA query**: product search already goes through `ProductElasticsearchRepository` (§ `spring/elasticsearch.md`), and district filtering is naturally a search-time filter alongside existing relevance/fuzziness scoring — re-deriving this in JPQL would create a second, divergent search path for the same data.
+
+**Explicitly deferred design questions** (do not implement against this sketch until resolved):
+- OQ-01 (strict-district vs. radius) — changes the entity relationship (`N:1` vs. `N:M`) and the ES query shape
+- OQ-02 (district reference data: fixed admin-maintained table vs. geocoded) — changes whether `District` is a simple lookup table (as sketched in §4.5.1/§4.5.2) or something more involved (geocoding integration, lat/long-based radius math instead of a discrete district match)
 
 ---
 
@@ -1656,6 +1690,8 @@ Bucket4j token-bucket strategy backed by Redis:
 | `HttpsEnforcementFilter`, `@PostConstruct` SSL check | SEC-03, FR-MON-01 | Security Overlay |
 | React SPA design (§4.3.6, §4.7.4, §4.10.5) | FR-FE-01–31 | Composition, Interface |
 | Domain events (`DomainEventPublisher`) | FR-INV-06, FR-PAY-04 | Logical, Interaction |
+| `Seller`, `District` entities *(Ph-3, Planned — not yet implemented)* | FR-SEL-01–08 | Information (§4.3.3, §4.5.1, §4.5.2) |
+| Location-Based Matching design sketch *(Ph-3, Planned — not yet implemented)* | FR-LOC-01–04 | Information (§4.5.6) |
 
 ---
 

--- a/docs/SDLC-docs/requirement-engineering/requirements-traceability-matrix.md
+++ b/docs/SDLC-docs/requirement-engineering/requirements-traceability-matrix.md
@@ -10,14 +10,14 @@
 | :--- | :--- |
 | **Document Title** | Requirements Traceability Matrix (RTM) |
 | **Document ID** | RTM-BUILDNEST-001 |
-| **Version** | 1.24 |
-| **Date** | 2026-07-22 10:30 IST |
+| **Version** | 1.26 |
+| **Date** | 2026-07-22 17:30 IST |
 | **Status** | Controlled — Under Review |
 | **Classification** | Internal Use |
 | **Conformance Standard** | ISO/IEC/IEEE 29148:2018 §6.2.5 (Traceability) |
-| **Related SRS** | SRS-BUILDNEST-001 v4.9 — `docs/SDLC-docs/requirement-engineering/software-requirements-specification.md` |
-| **Related SDD** | SDD-BUILDNEST-001 v3.6 — `docs/SDLC-docs/design/software-design-description.md` |
-| **Related TP** | TP-BUILDNEST-001 v4.2 — `docs/SDLC-docs/software-testing/test-plan.md` |
+| **Related SRS** | SRS-BUILDNEST-001 v5.1 — `docs/SDLC-docs/requirement-engineering/software-requirements-specification.md` |
+| **Related SDD** | SDD-BUILDNEST-001 v4.1 — `docs/SDLC-docs/design/software-design-description.md` |
+| **Related TP** | TP-BUILDNEST-001 v4.3 — `docs/SDLC-docs/software-testing/test-plan.md` |
 | **Baseline Assessment** | `docs/reports/baseline-assessment-2026-06-19.md` |
 
 ---
@@ -52,7 +52,9 @@
 | 1.21 | 2026-07-21 14:00 IST | QA Manager | FR-ADM-02 (inventory analytics and reports) corrected from 🔵 Pending Ph-2 to ✅ Implemented: `AdminInventoryAnalyticsController`/`InventoryAnalyticsService` were already fully implemented and tested, but had no frontend consumer (#432, direct 1:1 mirror of the FR-ADM-01/#431 `SalesAnalyticsTab.tsx` stat-card + list pattern — no chart library). Added `InventoryAnalyticsTab.tsx` (high-demand/low-stock list, seasonal demand patterns, stock turnover, and an on-demand predictive restocking plan) with `InventoryAnalyticsTab.test.tsx` coverage, and extended the citation. `FR-INV-07` (which additionally covers `InventoryReportService`/`AdminInventoryReportController`, out of #432's scope) stays 🔵 Pending Ph-2 — not marked Implemented by this change. Recomputed the Admin Operations (FR-ADM) Coverage Summary row (8→9 Implemented, 1→0 Pending), the Coverage Summary Totals row (120→121 Implemented, 47→46 Pending), and the §12 Phase 2 Admin full-suite Started/Not-Started counts (3→4 Started, 3→2 Not Started) and Phase 2 total (38→39 Started, 43→42 Not Started) | Pending |
 | 1.23 | 2026-07-22 09:30 IST | QA Manager | FR-INV-04 (admin updates stock quantities): eliminated the `Product.stockQuantity`/`Inventory` dual source of truth (#485, follow-up from #309) — `Product.stockQuantity` is no longer a persisted column, only a derived getter reading `Inventory.quantityInStock`, so there is exactly one writable representation of stock. Confirmed the drift was already live (not hypothetical): `ProductServiceImpl.updateProduct()` wrote `Product.stockQuantity` from the request without touching `Inventory`, desyncing the two on every ordinary edit. `CreateProductRequest.stockQuantity` is now create-only; stock changes on an existing product must go through `AdminInventoryController`'s adjust-inventory endpoint. Added `ProductInventorySingleSourceOfTruthIT` as the regression guard (real H2 persistence, not mocks — proves an update carrying a different `stockQuantity` does not change the persisted `Inventory` row). Extended FR-INV-04's Test citation; status stays ✅ Implemented (no functional capability changed, only the storage/consistency guarantee) — no count changes |
 | 1.24 | 2026-07-22 10:30 IST | QA Manager | FR-INV-03 (admin adds stock) / FR-INV-04 (admin updates stock quantities): closed a server-side floor-validation gap (#487, discovered during #440) — `AdminInventoryController.addStock()`/`updateStock()`'s `@RequestParam Integer quantity` had no `@Min(0)`, and `InventoryServiceImpl.addStock()`/`updateStock()` performed no defensive check either, so a negative value (bypassing the frontend's client-side guard, e.g. via a raw API client) could push `Inventory.quantityInStock` negative with no validation error. Fixed via `@Min(0)` + `@Validated` on the controller (added a `ConstraintViolationException` handler to `GlobalExceptionHandler`, which didn't exist before) and a defensive service-layer check in both methods, matching this repo's existing defense-in-depth pattern (`@PreAuthorize` at both URL and service layers). Both Test citations already list `AdminInventoryControllerTest`/`InventoryServiceImplTest` — no new test class added, both extended with negative-quantity cases (2 MockMvc tests proving real bean-validation binding, 3 unit tests including a corrupted-pre-existing-row scenario). Status stays ✅ Implemented for both (no functional capability changed, only the validation guarantee) — no count changes |
+| 1.25 | 2026-07-22 16:00 IST | QA Manager | **Marketplace pivot addendum**, RTM counterpart to SRS v5.0/SDD v4.0's FG-11/FG-12 addendum. Added §6.11 (Seller & Marketplace Management, FR-SEL-01–08) and §6.12 (Location-Based Matching, FR-LOC-01–04), all rows ⬜ Not Started — nothing in this addendum is implemented. Added both new categories to the Coverage Summary (§3) as separate rows explicitly excluded from the existing Totals row, matching the same treatment SRS §4.2/SDD §7 already gave this addendum. Also found and fixed pre-existing cross-reference drift independent of this addendum: `Related SDD` was stale at v3.6 (actual current v3.8 before this revision's own v4.0 bump) and `Related TP` was stale at v4.2 (actual current v4.3) — both corrected alongside the `Related SRS` 4.9→5.0 update this addendum itself required | Pending |
 | 1.22 | 2026-07-21 18:10 IST | QA Manager | FR-INV-07 (admin inventory analytics and reports) corrected from 🔵 Pending Ph-2 to ✅ Implemented: `AdminInventoryReportController`/`InventoryReportService` (the report/breach half of FR-INV-07, left explicitly out of scope by #432/1.21) had no frontend consumer (#433, direct 1:1 mirror of the FR-ADM-02/#432 `InventoryAnalyticsTab.tsx` admin-dashboard-tab pattern). Added `InventoryThresholdsTab.tsx` (summary stats, below-threshold products with inline minimum-level editing via `AdminInventoryThresholdController.setProductThreshold`, threshold breach list, frequently low-stock products) with `InventoryThresholdsTab.test.tsx` coverage, and extended the FR-INV-07 citation. FR-ADM-06 (admin configures inventory alert thresholds) citation also extended to the same new component — status stays 🟡 Partial, since only product-level threshold configuration shipped; category-level threshold configuration and the category-inheritance toggle (`AdminInventoryThresholdController.setCategoryThreshold`/`useProductCategoryThreshold`) remain deferred, tracked as a follow-up issue. Note: the issue's own body cited `AdminThresholdController` as an alternate controller name for this feature — verified against source and found incorrect; that controller is unrelated (system-monitoring CPU/memory/error-rate thresholds), not inventory. Recomputed the Inventory (FR-INV) Coverage Summary row (5→6 Implemented, 2→1 Pending), the Coverage Summary Totals row (121→122 Implemented, 46→45 Pending), and the §12 Phase 2 "Auth / Safety / Checkout / Inventory Ph-2" Started/Not-Started counts (0→1 Started, 10→9 Not Started) and Phase 2 total Started/Not-Started (39→40 / 42→41) | Pending |
+| 1.26 | 2026-07-22 17:30 IST | QA Manager | FR-SEL-01 (seller registration, distinct from a buyer account) corrected from ⬜ Not Started to ✅ Implemented (#553, first requirement implemented from the Ph-3 marketplace-pivot addendum): `Seller` entity/Liquibase changeset (1:1 extension of `User`, mirrors `Address`), `SellerServiceImpl.registerSeller`/`SellerController`, granting `ROLE_SELLER` on registration. `district_id` is a deliberately deferred/nullable column — the SDD's own `Seller ──[N:1]──► District` FK depends on ADR #561 (OQ-01/OQ-02), still open; registration does not functionally require it. Recomputed the Seller & Marketplace (FR-SEL) Coverage Summary row (0→1 Implemented, 8→7 Not Started) — Totals row unaffected (this category stays explicitly excluded per 1.25) | Pending |
 
 ### Document Approval
 
@@ -129,8 +131,12 @@ The RTM serves to:
 | Design Constraints (DC) | 8 | 7 | 1 | 0 | 0 | 0 |
 | Test Integrity (TIR) | 5 | 4 | 1 | 0 | 0 | 0 |
 | **Totals** | **183** | **122** | **16** | **45** | **0** | **0** |
+| Seller & Marketplace (FR-SEL) *(Ph-3, Planned — excluded from Totals above)* | 8 | 1 | 0 | 0 | 0 | 7 |
+| Location-Based Matching (FR-LOC) *(Ph-3, Planned — excluded from Totals above)* | 4 | 0 | 0 | 0 | 0 | 4 |
 
 > **Phase 1 gate posture**: 93 requirements fully implemented, 0 open defects. TIR-01 through TIR-04 and MNT-03 (previously blocking Phase 1 exit) were verified fixed on 2026-07-17 (#452) — `ProductApiTest`/`OrderApiTest` are `@Tag("e2e")`, `AuthServiceImplTest` mocks `RoleRepository`, both security-test assertions match their actual (correct) HTTP status codes, and MNT-02/TIR-05's coverage-gate values were corrected to their real, higher configured thresholds (85% JaCoCo, 77% PIT). Phase 1 is no longer blocked by test-integrity defects. (Totals recomputed directly from the 24 category rows above — the previous release's Totals row did not actually sum to its own category rows, independent of this fix.)
+>
+> **Ph-3 (Marketplace Expansion) posture**: 12 requirements added by the SRS v5.0/SDD v4.0 marketplace-pivot addendum, all ⬜ Not Started — deliberately excluded from the Totals row above, which represents existing Ph-1/Ph-2 tracked scope. These will be folded into Totals once implementation begins and the OQ-01/OQ-02 design questions (§6.12) are resolved.
 
 ---
 
@@ -344,6 +350,32 @@ The RTM serves to:
 | FR-FE-29 | Breadcrumb navigation | Low | Ph-2 | §4.3.6 | None found — no Breadcrumb component exists anywhere in `frontend/src/` | Playwright | Demonstration | 🔵 Pending Ph-2 |
 | FR-FE-30 | ErrorBoundary with fallback UI | Medium | Ph-2 | §4.3.6 | `frontend/src/components/common/ErrorBoundary.tsx` (class component, `getDerivedStateFromError`/`componentDidCatch`, renders a real fallback UI with reload button) | `ErrorBoundary.test.tsx` | Test | ✅ Implemented |
 | FR-FE-31 | Admin category management | Medium | Ph-2 | §4.7.4 | `frontend/src/components/admin/CategoriesTab.tsx`, `frontend/src/components/admin/CategoryFormModal.tsx` | Vitest | Test | ✅ Implemented (#428) |
+
+### 6.11 Seller & Marketplace Management (FG-11) *(Ph-3, Planned)*
+
+> No implementation exists for any row below — added as part of the marketplace-pivot addendum (SRS v5.0, SDD v4.0). See SDD §4.5.2's note on the existing dormant `product.supplier_id` FK as the likely reactivation target for FR-SEL-03, once the `Seller`/`District` design is finalised.
+
+| Req ID | Description | Priority | Phase | SDD Reference | Implementation | Test Class(es) | Verification | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| FR-SEL-01 | Seller registration, distinct from a buyer (USER) account | High | Ph-3 | §4.3.3, §4.5.1, §4.5.2 | `Seller` entity/changeset, `SellerServiceImpl.registerSeller`, `SellerController` (#553). `district_id` deliberately deferred/nullable pending ADR #561 (OQ-01/OQ-02) | `SellerServiceImplTest`, `SellerControllerTest`, `SellerRegistrationIT` | Test | ✅ Implemented |
+| FR-SEL-02 | Admin verification/approval before a seller can list products | High | Ph-3 | §4.5.2 | Not started | — | Test | ⬜ Not Started |
+| FR-SEL-03 | Each product associated with exactly one owning seller | High | Ph-3 | §4.5.2 (dormant `product.supplier_id` FK) | Not started | — | Test | ⬜ Not Started |
+| FR-SEL-04 | Seller manages their own product listings only | High | Ph-3 | §4.5.1, §4.5.2 | Not started | — | Test | ⬜ Not Started |
+| FR-SEL-05 | Seller manages inventory for their own products only | High | Ph-3 | §4.5.1, §4.5.2 | Not started | — | Test | ⬜ Not Started |
+| FR-SEL-06 | Seller views/manages orders containing their own products only | High | Ph-3 | §4.5.1 | Not started | — | Test | ⬜ Not Started |
+| FR-SEL-07 | Buyers rate/review individual sellers | Medium | Ph-3 | §4.5.1 | Not started | — | Test | ⬜ Not Started |
+| FR-SEL-08 | Seller cannot access/modify another seller's data (defense in depth) | High | Ph-3 | Security Overlay (pattern per `spring/spring-security.md`) | Not started | — | Test | ⬜ Not Started |
+
+### 6.12 Location-Based Matching (FG-12) *(Ph-3, Planned)*
+
+> No implementation exists for any row below. §3.2.12's Open Questions (OQ-01 strict-district vs. radius; OQ-02 fixed reference table vs. geocoded) are unresolved — see SDD §4.5.6 for why these rows cannot be finalised into a concrete design yet.
+
+| Req ID | Description | Priority | Phase | SDD Reference | Implementation | Test Class(es) | Verification | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| FR-LOC-01 | Record a district (or equivalent) for each seller | High | Ph-3 | §4.5.1, §4.5.2 | Not started | — | Test | ⬜ Not Started |
+| FR-LOC-02 | Record a district (or equivalent) for each buyer | High | Ph-3 | §4.5.1, §4.5.2 | Not started | — | Test | ⬜ Not Started |
+| FR-LOC-03 | Restrict buyer's catalogue view to district-matching sellers | High | Ph-3 | §4.5.6 | Not started | — | Test | ⬜ Not Started |
+| FR-LOC-04 | Prevent checkout from a seller outside the buyer's matching radius | High | Ph-3 | §4.5.6 | Not started | — | Test | ⬜ Not Started |
 
 ---
 

--- a/docs/SDLC-docs/requirement-engineering/software-requirements-specification.md
+++ b/docs/SDLC-docs/requirement-engineering/software-requirements-specification.md
@@ -10,8 +10,8 @@
 | :--- | :--- |
 | **Document Title** | Software Requirements Specification (SRS) |
 | **Document ID** | SRS-BUILDNEST-001 |
-| **Version** | 4.9 |
-| **Date** | 2026-07-19 10:40 IST |
+| **Version** | 5.1 |
+| **Date** | 2026-07-22 15:00 IST |
 | **Status** | Controlled — Under Review |
 | **Classification** | Internal Use |
 | **Conformance Standard** | ISO/IEC/IEEE 29148:2018 |
@@ -38,6 +38,8 @@
 | 4.7 | 2026-07-19 06:00 IST | Technical Lead | Added FR-ADM-10 (admin manages product tags — create/view/update/delete) to §3.2.8 — no FR row existed for tag management at all despite `AdminProductTagController`'s backend already being fully implemented and Appendix A.19 already documenting its endpoints; the admin frontend UI for it was built in the same change (#429). Recomputed §4.2's Admin Operations aggregate row (9→10 requirements, 6→7 Medium) | Pending |
 | 4.8 | 2026-07-19 09:00 IST | Technical Lead | Added FR-ADM-11 (admin manages coupons — view, create, deactivate) to §3.2.8. Appendix A.20's endpoint table was itself stale, listing only `POST`/`DELETE` — corrected to include the `GET` list endpoint added in the same change (#435), since the admin frontend UI (`CouponsTab.tsx`) can't function without one, matching the pattern already fixed once for A.19. Recomputed §4.2's Admin Operations aggregate row (10→11 requirements, 7→8 Medium) | Pending |
 | 4.9 | 2026-07-19 10:40 IST | Technical Lead | Added FR-CHK-09 (users apply a coupon/discount code during checkout) to §3.2.4 — the backend endpoint (`MultiStepCheckoutController.applyCoupon`, `/api/v1/checkout/coupon`) already existed and was already documented in Appendix A.10, but no requirement row was ever added for it despite FR-ADM-11's sibling admin-side requirement existing since #435; the customer-facing frontend wiring (coupon input on the checkout Shipping step, discount reflected in order-summary/payment totals) was built in the same change (#436). Recomputed §4.2's Checkout aggregate row (8→9 requirements, 2→3 Medium) | Pending |
+| 5.0 | 2026-07-22 15:00 IST | Technical Lead | **Marketplace pivot addendum.** Promoted FUT-02 ("Multi-vendor marketplace support") from a one-line deferred placeholder into a scoped requirements addendum, following a business-model discussion establishing the platform's actual direction: a district/location-scoped multi-seller marketplace connecting existing offline construction-material and décor shops to nearby buyers, phased B2C-first with a B2B (bulk/RFQ) extension to follow. Added: new Ph-3 delivery phase (§2.8) for this expansion, distinct from Ph-1/Ph-2's stabilisation-and-production-readiness scope; new SELLER user characteristic (§2.3); new SN-08 stakeholder need (§2.7); two new Feature Groups, FG-11 Seller & Marketplace Management and FG-12 Location-Based Matching, with placeholder FR-SEL-* / FR-LOC-* requirement rows (§3.2.11, §3.2.12) — all rows explicitly Phase=Ph-3 and unverified (nothing in this addendum is implemented yet; no backend/frontend code changed in this revision). Updated §1.2 Scope and §1.3.2/§2.2 Product Functions Summary to list the two new groups. This is additive only — no existing FR row was removed, renumbered, or reinterpreted; existing Ph-1/Ph-2 requirements and their RTM traceability are unaffected. SDD/RTM/Test Plan updates to follow as separate revisions once this addendum is reviewed | Pending |
+| 5.1 | 2026-07-22 17:30 IST | Technical Lead | FR-SEL-01 (seller registration) implemented (#553) — first requirement delivered from the Ph-3 marketplace-pivot addendum. Updated §4.2's Seller & Marketplace aggregate status row (0→1 Implemented, 8→7 Not started); Grand Total unaffected (category stays explicitly excluded per v5.0) | Pending |
 
 ### Document Change Procedure
 
@@ -131,6 +133,7 @@ The purpose of this document is to:
 | Admin Operations | Analytics, reports, user management, inventory administration, audit logs |
 | Monitoring & Observability | Health checks, Prometheus metrics, alerting, structured log aggregation |
 | Frontend Application | Responsive React SPA with client-side routing, state management, form validation |
+| Seller & Marketplace Management *(Ph-3, Planned)* | Seller onboarding/verification, seller-owned product catalogue, district-based seller-buyer matching — see §3.2.11–§3.2.12 |
 
 **System Boundary**: This SRS covers the entire BuildNest platform — the **Spring Boot 3.5 backend API** and the **React 19 Frontend SPA**.
 
@@ -175,6 +178,8 @@ The system is designed for deployment on **Kubernetes** (manifests provided) or 
 | FG-08 | Admin Operations | User management, order management, product management, analytics, reports, audit logs |
 | FG-09 | Monitoring & Alerting | Health checks (DB, Redis), Prometheus metrics, Elasticsearch alerting, webhook events |
 | FG-10 | Frontend Experience | Responsive SPA, client-side routing, form validation, error handling, state management |
+| FG-11 | Seller & Marketplace Management *(Ph-3, Planned)* | Seller onboarding/verification, seller-owned product catalogue, seller dashboard |
+| FG-12 | Location-Based Matching *(Ph-3, Planned)* | District-scoped seller/product visibility for buyers, based on transport-cost constraints |
 
 #### 1.3.3 System Interfaces
 
@@ -326,6 +331,8 @@ BuildNest is a new, self-contained product. It is not a replacement for or enhan
 | FG-08 | Admin Operations | User management, order management, product management, analytics, reports, audit logs |
 | FG-09 | Monitoring & Alerting | Health checks, Prometheus metrics, Elasticsearch alerting, webhook events |
 | FG-10 | Frontend Experience | Responsive SPA, client-side routing, form validation, error handling, state management |
+| FG-11 | Seller & Marketplace Management *(Ph-3, Planned)* | Seller onboarding/verification, seller-owned product catalogue, seller dashboard |
+| FG-12 | Location-Based Matching *(Ph-3, Planned)* | District-scoped seller/product visibility for buyers, based on transport-cost constraints |
 
 ### 2.3 User Characteristics
 
@@ -333,6 +340,7 @@ BuildNest is a new, self-contained product. It is not a replacement for or enhan
 | :--- | :--- | :--- | :--- |
 | **End User (USER)** | Registered customer browsing and purchasing products | Low to moderate; interacts via frontend SPA | Browse products, manage cart, place orders, write reviews, manage wishlist |
 | **Administrator (ADMIN)** | Platform operator managing products, inventory, and system health | Moderate to high; may use admin UI or direct API | Manage products/inventory, view analytics/reports, manage users, audit logs |
+| **Seller (SELLER)** *(Ph-3, Planned)* | Verified offline shop owner (construction materials or décor) selling through the platform to buyers within their district | Low to moderate; interacts via seller dashboard | Manage own product listings/inventory, view own orders, fulfil within served districts |
 | **API Consumer (Developer)** | Frontend or third-party developer integrating with the API | High; direct REST API interaction | All API endpoints per granted role |
 | **DevOps / SRE** | Operations team managing deployment and monitoring | High; infrastructure and monitoring tools | Deployment, health monitoring, alerting, disaster recovery |
 
@@ -386,7 +394,7 @@ Requirements deferred to future releases:
 | ID | Requirement | Target Release |
 | :--- | :--- | :--- |
 | FUT-01 | Kafka-based event streaming (infrastructure present; not active) | v1.1 |
-| FUT-02 | Multi-vendor marketplace support | v2.0 |
+| FUT-02 | Multi-vendor marketplace support — scoped in §3.2.11 (FG-11) / §3.2.12 (FG-12); B2B bulk/RFQ extension remains deferred beyond Ph-3 | Ph-3 |
 | FUT-03 | Native mobile application (iOS / Android) | v2.0 |
 | FUT-04 | Multi-region deployment | v2.0 |
 | FUT-05 | Pact consumer contract tests (infrastructure present; 0 active tests) | v1.1 |
@@ -404,15 +412,17 @@ Per ISO/IEC/IEEE 29148:2018 Clause 6.3:
 | SN-05 | DevOps / SRE | Observable, container-ready application with zero-downtime deployments | FG-09, PRT-01–04 |
 | SN-06 | Security Auditors | Compliance with OWASP, PCI-DSS, and GDPR standards | SEC-01–14 |
 | SN-07 | QA Engineers | A test suite whose pass signal is trustworthy and reflects real system behaviour | TIR-01–05 |
+| SN-08 | Sellers *(Ph-3, Planned)* | A way to reach buyers beyond their existing offline shop's foot traffic, within a service area they can realistically fulfil | FG-11, FG-12 |
 
 ### 2.8 Delivery Phases
 
-All requirements are classified by delivery phase. Phase 1 is a prerequisite for Phase 2.
+All requirements are classified by delivery phase. Phase 1 is a prerequisite for Phase 2. Phase 3 is a business-model expansion, not a further stabilisation step — it is independent of Ph-1/Ph-2's technical-debt scope and may proceed once Ph-2 is reasonably stable, without requiring Ph-2's full completion criteria to be met first.
 
 | Phase | Name | Goal | Completion Criteria |
 | :--- | :--- | :--- | :--- |
 | **Ph-1** | **Stable** | Backend build gate is trustworthy; zero test failures | `./mvnw test -P unit-tests` reports 0 failures, 0 errors |
 | **Ph-2** | **Production Ready** | System is deployable, observable, secure, and end-user accessible | All Ph-2 requirements met; staging validation passed; frontend functional |
+| **Ph-3** | **Marketplace Expansion** *(Planned)* | Platform supports multiple verified sellers, each district-scoped, selling to buyers via a B2C flow; B2B (bulk/RFQ) is an explicit later sub-phase, not required for Ph-3 completion | All Ph-3 FR-SEL-*/FR-LOC-* requirements implemented and tested; seller onboarding, district matching, and B2C checkout against seller-owned products functional end-to-end |
 
 ---
 
@@ -631,6 +641,41 @@ This system has no direct hardware interfaces. It runs as a containerised applic
 | FR-FE-28 | ProductCard: product image, name, price, rating, "Add to Cart" | High | Ph-2 | Demonstration |
 | FR-FE-29 | Breadcrumb: navigation hierarchy on product and category pages | Low | Ph-2 | Demonstration |
 | FR-FE-30 | ErrorBoundary: catches React rendering errors and displays a fallback UI | Medium | Ph-2 | Test |
+
+---
+
+#### 3.2.11 Seller & Marketplace Management (FG-11) — *Ph-3, Planned*
+
+> **Status note**: Every requirement in this subsection is planned, not implemented. No `Seller` entity, onboarding flow, or seller-scoped catalogue exists in the codebase as of v5.0 of this document. Verification method stated is the intended method once built; none of these rows are currently verifiable.
+
+| ID | Requirement | Priority | Phase | Verification |
+| :--- | :--- | :--- | :--- | :--- |
+| FR-SEL-01 | The system shall allow a prospective seller to register an account distinct from a buyer (USER) account | High | Ph-3 | Test |
+| FR-SEL-02 | The system shall require admin verification/approval of a seller registration (e.g. shop registration/GST details) before the seller can list products | High | Ph-3 | Test |
+| FR-SEL-03 | The system shall associate each product with exactly one owning seller | High | Ph-3 | Test |
+| FR-SEL-04 | The system shall allow a verified seller to create, update, and remove their own product listings, scoped to only their own products | High | Ph-3 | Test |
+| FR-SEL-05 | The system shall allow a verified seller to manage inventory/stock for their own products only | High | Ph-3 | Test |
+| FR-SEL-06 | The system shall allow a verified seller to view and manage orders containing their own products only | High | Ph-3 | Test |
+| FR-SEL-07 | The system shall allow buyers to rate and review individual sellers, in addition to existing per-product reviews (FG-07) | Medium | Ph-3 | Test |
+| FR-SEL-08 | The system shall prevent a seller from accessing or modifying another seller's products, inventory, or orders (defense in depth: URL authorisation + method-level `@PreAuthorize` per existing RBAC convention) | High | Ph-3 | Test |
+
+#### 3.2.12 Location-Based Matching (FG-12) — *Ph-3, Planned*
+
+> **Status note**: Every requirement in this subsection is planned, not implemented. The current product search/catalogue (FG-02, Elasticsearch-backed) has no geographic dimension. This subsection intentionally leaves the district-matching mechanism (strict same-district vs. seller-selected delivery radius) undecided — see Open Questions below; requirement wording will be finalised once that design decision is made (`solution-options-adr`).
+
+| ID | Requirement | Priority | Phase | Verification |
+| :--- | :--- | :--- | :--- | :--- |
+| FR-LOC-01 | The system shall record a district (or equivalent administrative area) for each seller | High | Ph-3 | Test |
+| FR-LOC-02 | The system shall record a district (or equivalent) for each buyer, derived from their registered/delivery address | High | Ph-3 | Test |
+| FR-LOC-03 | The system shall restrict the product catalogue a buyer browses/searches to sellers matching the buyer's district-matching rule (exact match or seller-declared delivery radius — mechanism TBD, see Open Question OQ-01) | High | Ph-3 | Test |
+| FR-LOC-04 | The system shall prevent checkout of a product from a seller outside the buyer's permitted matching radius | High | Ph-3 | Test |
+
+**Open Questions (to resolve before implementation):**
+
+| ID | Question | Status |
+| :--- | :--- | :--- |
+| OQ-01 | Is district matching strict (buyer sees only same-district sellers) or radius-based (seller declares which nearby districts they'll deliver to)? | Open |
+| OQ-02 | Is district determined from a fixed, admin-maintained reference table, or free-text/geocoded from address? | Open |
 
 ---
 
@@ -913,6 +958,8 @@ Test integrity requirements define the properties that the test suite itself mus
 | Test Integrity (TIR-01–05) | 5 | Ph-1 / Ph-2 | 2 High, 3 Medium | Build, Inspection |
 | **Total Non-Functional** | **61** | | | |
 | **Grand Total** | **156** | | | |
+| Seller & Marketplace (FR-SEL-01–08) *(Ph-3, Planned — excluded from Grand Total above)* | 8 | Ph-3 | 6 High, 2 Medium | 1 Implemented (#553), 7 Not started |
+| Location-Based Matching (FR-LOC-01–04) *(Ph-3, Planned — excluded from Grand Total above)* | 4 | Ph-3 | 4 High | Not started |
 
 ### 4.3 Phase 1 Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- Implements FR-SEL-01 (issue #553) — the first requirement delivered from the Ph-3 marketplace-pivot addendum (Epic #552).
- Adds `Seller` entity (1:1 extension of `User`, mirroring the existing `Address` pattern), a Liquibase changeset, `SellerService`/`SellerController` for `POST /api/user/seller/register` and `GET /api/user/seller/profile`, and grants `ROLE_SELLER` on registration.
- `district_id` is deliberately a nullable column with no FK constraint: the SDD's planned `Seller ──N:1──► District` FK depends on unresolved ADR #561 (OQ-01/OQ-02 — strict same-district vs. seller-declared-radius matching, which changes the FK's actual cardinality). Registration itself doesn't need it; district assignment is a follow-up once #561 resolves. Confirmed via `AskUserQuestion` before implementing.
- Adds a `DuplicateResourceException` → 409 handler to `GlobalExceptionHandler` — the exception class existed but had no handler before this issue (would have fallen through to a 500).
- RTM/SRS/SDD updated (FR-SEL-01 row/status, Document Control version bumps, direct cross-reference pointers).

## Test plan
- [x] `SellerServiceImplTest` — unit tests (registration, duplicate rejection, unknown user, null-roles regression)
- [x] `SellerControllerTest` — unit tests (response status codes)
- [x] `SellerRegistrationIT` — `@SpringBootTest`/H2 integration test proving the real Liquibase changeset + entity mapping + role grant round-trip (caught a real NPE — `user.getRoles()` can be null — that the mocked unit tests missed; fixed and added a dedicated regression test for it)
- [x] `./mvnw test -Dtest=SellerServiceImplTest,SellerControllerTest,SellerRegistrationIT` — all green locally
- [ ] CI: JaCoCo, PIT, CheckStyle, SpotBugs, SonarCloud — to be watched on this PR