### PR TITLE
docs: refresh README M4 issue count [self-correction from #553]

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 191/212 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 193/226 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 52/90 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
Self-correction, not a new-scope follow-up — #553's own closure deferred this re-check to "actual closure time" per the `aggregate-fact-deferred` rule, but never returned to it (caught by a `/critique-prompt` retrospective).

README's M4 row stated `191/212 issues closed`. Real current count (`gh api repos/.../milestones/4`): 193 closed, 33 open (226 total). The 212 total was already stale independent of #553 (more issues accumulated in M4 since the count was last refreshed, including #552–#565).

## Test plan
- [x] Value verified fresh via `gh api repos/.../milestones/4` immediately before editing
- [x] Docs-only change (tier 0 per testing.md) — no code path to test