### PR TITLE
docs: refresh README M4/M5 issue counts (self-correction, #554)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 193/226 issues closed |
-| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 52/90 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 194/227 issues closed |
+| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---
 


### PR DESCRIPTION
## Summary
Self-correction, not a new/separate concern: #554's own closure (plus follow-up #569 filed into the same milestone) drifted README's M4 count stale (193/226 -> 194/227), the exact \`aggregate-fact-deferred\` pattern flagged during #554's own closing steps but not resolved at the time. M5 (52/90 -> 53/94) found stale in the same table while verifying M4, fixed in the same pass.

## Verification
- \`gh api repos/pradip9096/buildnest-ecommerce-platform/milestones/4\` -> closed:194, open:33 (=227 total)
- \`gh api repos/pradip9096/buildnest-ecommerce-platform/milestones/5\` -> closed:53, open:41 (=94 total)
- M1/M2/M3 rows checked against the same API, already accurate — untouched

Traces to #554 (FR-SEL-02).