### PR TITLE
docs: self-correct README M4 issue count (194->195, #555)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 194/227 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 195/227 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
- Self-correction, not a new finding: #555's own closure moved M4's milestone count 194→195/227 (verified via \`gh api .../milestones/4\`). README was updated pre-merge but the count could only be verified accurate *after* #555 actually closed.

## Test plan
- [x] Verified against live \`gh api repos/pradip9096/buildnest-ecommerce-platform/milestones/4\` (closed: 195, total: 227)