### PR TITLE
docs: self-correct README M4 issue count after #556 closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 195/227 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 196/228 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---


### PR DESCRIPTION
Self-correction PR, not an independent follow-up — exists because #556's own closure (PR #574 merge + follow-up #576 filed) changed the milestone's real numbers. README stated 195/227; actual is 196/228 (verified via \`gh api .../milestones/4\`).