### PR TITLE
docs: self-correct README M4 issue count after #578 closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 196/228 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 197/232 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
- Self-correction (not a new-scope follow-up): #578's own closure (PR #582) shifted M4's issue count. Deferred per the aggregate-fact-deferred rule at #578's commit time, resolved here against the real milestone API value.
- 196/228 → 197/232 issues closed.

## Test plan
- [x] Verified via `gh api repos/pradip9096/buildnest-ecommerce-platform/milestones/4` — closed: 197, open: 35 (232 total)