### PR TITLE
docs: self-correct README M4 issue count after #580/#557 closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 198/232 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 200/232 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
- Self-correction (not an independent follow-up): #580's own merge, plus parent epic #557 closing in the same session, drifted README's M4 roadmap count from 198/232 to 200/232. Deferred at #587's commit time per `aggregate-fact-deferred` discipline since #580 hadn't merged yet; resolved now with the verified real value (`gh api .../milestones/4`).

## Test plan
- [x] Doc-only change, no code path — value verified directly against the milestone API