### PR TITLE
docs: establish ADR directory (MADR), link to development-workflow.md steps 8/23

### DIFF
--- a/docs/SDLC-docs/design/adr/0000-use-markdown-any-decision-records.md
+++ b/docs/SDLC-docs/design/adr/0000-use-markdown-any-decision-records.md
@@ -1,0 +1,77 @@
+# 0000. Use Markdown Any Decision Records
+
+* Status: accepted
+* Date: 2026-07-26
+* Issue: —
+
+## Context and Problem Statement
+
+BuildNest's `solution-options-adr` workflow step (`development-workflow.md`)
+already requires real architectural decisions to be written up, but had no
+dedicated file location or format — decisions have historically lived
+scattered across Amendment Log prose, PR descriptions, and knowledge-base
+articles, with no single place a reader can browse to see "what decisions
+were made and why" independent of which document happened to record one.
+
+## Decision Drivers
+
+* Needs to be plain Markdown, consistent with every other SDLC doc in this
+  repo (RTM/SRS/SDD/Test Plan/SDP are all Markdown, not a proprietary tool)
+* Should be a recognized, tool-agnostic convention rather than an invented
+  one-off format, so it's legible to anyone familiar with ADRs generally
+* Low overhead — this repo already has extensive process ceremony
+  (`development-workflow.md`'s own Amendment Log discipline); the ADR
+  format itself should not add more
+
+## Considered Options
+
+* MADR (Markdown Any Decision Records)
+* Michael Nygard's original ADR format (Title/Status/Context/Decision/
+  Consequences, no separate "Considered Options" section)
+* No dedicated format — keep recording decisions inline in Amendment Log
+  entries and PR descriptions, as already happening
+
+## Decision Outcome
+
+Chosen option: "MADR", because it is the most widely recognized Markdown
+ADR convention, is actively maintained (v4.0.0), and its "Considered
+Options" / "Decision Drivers" sections map directly onto the trade-off
+comparisons `solution-options-adr` already asks for (e.g. #578's
+per-seller-order-splitting decision, #453's location-matching design) —
+adopting it gives those write-ups a consistent shape instead of ad hoc
+prose structure each time.
+
+### Consequences
+
+* Good, because future architectural decisions get one canonical,
+  browsable location (this directory's index) instead of being scattered
+* Good, because the format's "Considered Options" section directly
+  encodes what `solution-options-adr`'s sibling-precedent check already
+  requires recording (what was compared, what was rejected, why)
+* Bad, because it adds one more artifact type to `update-docs`'s closing
+  enumeration — mitigated by making it conditional: only when a
+  `solution-options-adr` decision actually produced a new ADR in that
+  issue's own work, not on every issue
+
+## Pros and Cons of the Options
+
+### MADR
+
+* Good, because it is a maintained, versioned standard (adr.github.io)
+* Good, because its minimal template's mandatory sections (Context and
+  Problem Statement, Decision Drivers, Considered Options, Decision
+  Outcome) are lightweight enough not to add meaningful ceremony
+* Bad, because it is one more convention contributors need to learn
+
+### Nygard's original format
+
+* Good, because it is simpler (no separate options/drivers breakdown)
+* Bad, because it doesn't have a dedicated place to record what
+  alternatives were rejected and why — exactly the content
+  `solution-options-adr`'s sibling-precedent check already needs recorded
+
+### No dedicated format (status quo)
+
+* Good, because it requires no new convention or directory
+* Bad, because it is the status quo this ADR exists to fix — decisions
+  are unrecoverable except by searching Amendment Log prose or PR history

--- a/docs/SDLC-docs/design/adr/README.md
+++ b/docs/SDLC-docs/design/adr/README.md
@@ -1,0 +1,43 @@
+# Architecture Decision Records (ADR)
+
+This directory holds BuildNest's Architecture Decision Records, using the
+[MADR](https://adr.github.io/madr/) (Markdown Any Decision Records) format,
+current version 4.0.0.
+
+## When an ADR gets written here
+
+Referenced from
+[`development-workflow.md`](../../../../.claude/rules/common/development-workflow.md)'s
+Sequence table:
+
+- **Step `solution-options-adr`** — whenever a real architectural or design
+  decision is made (a genuine trade-off between competing approaches, not a
+  self-evident implementation choice), write it up as a new numbered ADR
+  here, following the [template](adr-template.md). This is where the
+  decision's actual content lives — `development-workflow.md`'s own Notes
+  cell only points here, it does not restate ADR content inline.
+- **Step `update-docs`** — whenever a `solution-options-adr` decision
+  produced a new ADR file in the same issue's work, that file is one of the
+  docs enumerated at closing time, alongside README/RTM/SRS/SDD/CHANGELOG/
+  test-plan.md.
+
+## Numbering and naming
+
+`NNNN-short-kebab-case-title.md`, four-digit zero-padded, sequential —
+e.g. `0001-split-multi-seller-cart-into-per-seller-orders.md`. `0000` is
+reserved for this directory's own genesis ADR (the decision to use MADR
+itself), following MADR's own convention.
+
+## Status values
+
+`proposed` | `accepted` | `rejected` | `deprecated` | `superseded by ADR-NNNN`
+
+## Index
+
+| ADR | Title | Status | Issue |
+| :--- | :--- | :--- | :--- |
+| [0000](0000-use-markdown-any-decision-records.md) | Use Markdown Any Decision Records | accepted | — |
+
+New entries are added here in the same edit that adds the ADR file — this
+index is not backfilled from git history retroactively; it starts tracking
+from `0000` onward.

--- a/docs/SDLC-docs/design/adr/adr-template.md
+++ b/docs/SDLC-docs/design/adr/adr-template.md
@@ -1,0 +1,43 @@
+# NNNN. Short title of the decision
+
+* Status: proposed | accepted | rejected | deprecated | superseded by ADR-NNNN
+* Date: YYYY-MM-DD
+* Issue: #NNN
+
+## Context and Problem Statement
+
+What is the issue we're seeing that motivates this decision? State it as a
+question if useful, in a few sentences.
+
+## Decision Drivers
+
+* driver 1 (e.g. a constraint, a quality attribute, a repo precedent)
+* driver 2
+
+## Considered Options
+
+* Option A
+* Option B
+* Option C
+
+## Decision Outcome
+
+Chosen option: "Option X", because [justification — the driver(s) that
+tipped it, or the fact that it's the only option meeting a hard constraint].
+
+### Consequences
+
+* Good, because [positive consequence]
+* Bad, because [negative consequence, deliberate trade-off accepted]
+
+## Pros and Cons of the Options
+
+### Option A
+
+* Good, because [argument]
+* Bad, because [argument]
+
+### Option B
+
+* Good, because [argument]
+* Bad, because [argument]


### PR DESCRIPTION
## Summary
- `docs/SDLC-docs/design/adr/` existed but was empty, untracked, and unreferenced anywhere in the repo.
- Populates it with a README (MADR convention + index), the MADR 4.0.0 minimal template, and a genesis ADR (`0000`) documenting the choice to adopt MADR itself.
- `development-workflow.md` (gitignored, local-only — not part of this diff) now points step 8 (`solution-options-adr`) write-ups at this directory and step 23 (`update-docs`) checks the ADR index conditionally, whenever step 8 produced a new ADR that issue.

## Test plan
- [x] Doc-only change, no code path