### PR TITLE
docs: self-correct README M4 issue count after #562 closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 205/233 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 206/238 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
- Nested self-correction PR — #562's own closure (via #610) caused the README's M4 issue count to drift, per the aggregate-fact-deferred rule (verify at closure, not guess).
- Re-verified via \`gh issue list --milestone "M4 — Feature Development"\`: 206 closed / 238 total (previously 205/233).

🤖 Generated with [Claude Code](https://claude.com/claude-code)