### PR TITLE
docs: self-correct README M4 issue count after #563 closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 206/238 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 207/238 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
- Nested self-correction PR, per work-on-issue.md's aggregate-fact-deferred rule — #563's own closure incremented the M4 milestone's closed-issue count, which README's Roadmap table states as an aggregate fact.
- README M4 row: 206/238 → 207/238 issues closed (re-verified via `gh issue list --milestone "M4 — Feature Development" --state all`).

Not an independently-scoped follow-up — exists solely because #563's own merge caused this drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)