### PR TITLE
docs: self-correct README M4 issue count after #564 closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 207/238 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 208/238 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---


### PR DESCRIPTION
Self-correction, not an independently-scoped follow-up: #564's own closure moved M4's count from 207/238 to 208/238. README was accurate at #564's commit time (per its own aggregate-fact-deferred check) but drifted the moment the issue closed. Re-verified via `gh api graphql` against the live milestone(4) state: 208 closed / 30 open / 238 total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)