### PR TITLE
fix(security): override swagger-ui to 5.32.11, patching CVE-2026-65898

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,14 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
 - (#558 follow-up) Extracted `AbstractReview` (`@MappedSuperclass`) for the remaining duplicated
   entity fields/`@PrePersist`/`@PreUpdate` callbacks between `ProductReview` and `SellerReview`,
   resolving the residual SonarCloud duplication (5.3% after the first fix, still above the 3% max).
+- (#611) Overrode `org.webjars:swagger-ui` to 5.32.11 via `dependencyManagement` — CVE-2026-65898
+  (CVSS 7.2, vendored DOMPurify) affected the 5.32.2 version bundled by
+  `springdoc-openapi-starter-webmvc-ui` 2.8.17 (the current latest springdoc release; no newer
+  springdoc version bundles a patched swagger-ui yet). Same override pattern already established
+  for other transitively-bundled CVEs in this `dependencyManagement` block (#332/PR #335). Local
+  `dependency-check:check -Powasp` could not fully verify (NVD sync crashes on a pre-existing tool
+  bug without an API key, same constraint documented in #341) — real verification is via this PR's
+  own CI `OWASP Dependency-Check` job.
 
 - Order-group schema for seller-scoped order splitting (FR-SEL-06, #578, first of three
   sub-issues under parent #557) — a cart spanning multiple sellers currently produces one

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -426,6 +426,20 @@
 				<artifactId>kotlin-stdlib-jdk8</artifactId>
 				<version>2.4.0</version>
 			</dependency>
+
+			<!-- CVE-2026-65898 (#611): springdoc-openapi-starter-webmvc-ui 2.8.17 (latest
+			     release as of this fix) still bundles org.webjars:swagger-ui 5.32.2, whose
+			     vendored DOMPurify has this CVE. No newer springdoc-openapi release bundles a
+			     patched swagger-ui yet, so override the webjar directly to the latest available
+			     release on Maven Central (5.32.11, includes the DOMPurify fix shipped in
+			     swagger-ui 5.32.7+). swagger-ui is a static UI bundle (webjar), not compiled
+			     Java code springdoc calls into by API surface, so a same-major.minor bump is
+			     safe without a springdoc-openapi version change. -->
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>swagger-ui</artifactId>
+				<version>5.32.11</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
## Summary
- `springdoc-openapi-starter-webmvc-ui` 2.8.17 (current latest release) bundles `org.webjars:swagger-ui` 5.32.2, whose vendored DOMPurify has CVE-2026-65898 (CVSS 7.2), failing `OWASP Dependency-Check` on unrelated PRs (e.g. #610).
- Confirmed via `./mvnw dependency:tree -Dincludes=org.webjars:swagger-ui` that no newer springdoc-openapi release is available that bundles a patched swagger-ui.
- Fix: override `org.webjars:swagger-ui` directly to 5.32.11 (latest on Maven Central, includes the DOMPurify fix shipped in swagger-ui 5.32.7+) via `dependencyManagement` — the same pattern already established for other transitively-bundled CVEs in this repo (#332/PR #335).
- Re-verified via `dependency:tree` that the override actually resolves (5.32.2 → 5.32.11).
- Local `dependency-check:check -Powasp` could not complete — NVD sync crashed on a pre-existing tool bug (oversized reference URL for CVE-2026-6785/6786) without an API key, the same underlying constraint documented in #341. Real verification is this PR's own CI `OWASP Dependency-Check` job, which has `NVD_API_KEY` configured.

## Test plan
- [x] `mvn dependency:tree` confirms `swagger-ui:5.32.11` resolves
- [ ] CI's `OWASP Dependency-Check` job passes (no CVE-2026-65898 finding)
- [ ] No new CVSS ≥ 7.0 findings introduced by the version bump itself

Closes #611