### PR TITLE
docs: self-correct README M4 issue count after #611 closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ GitHub Actions workflows in `.github/workflows/` that actively trigger on `maste
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 208/238 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 209/238 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 53/94 issues closed |
 
 ---


### PR DESCRIPTION
## Summary
- #611's merged PR (#617) closed the issue, moving M4 from 208/238 to 209/238 closed issues.
- Self-correction of an aggregate count #611's own closure caused to drift, not an independently-scoped follow-up.

## Test plan
- [x] Verified current count via `gh api .../milestones/4` (closed:209, open:29, 209+29=238)