### PR TITLE
fix(config): document RAZORPAY_WEBHOOK_SECRET in .env.example (#114 follow-up)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -299,6 +299,12 @@ RAZORPAY_KEY_ID=
 # Type: string | Class: SECRET | Req: REQUIRED (for checkout to function)
 RAZORPAY_KEY_SECRET=
 
+# Razorpay webhook signing secret (from the webhook config in the Razorpay
+# dashboard, not the API key secret above). No default (#114) — required
+# at startup whenever the app boots, not just for checkout.
+# Type: string | Class: SECRET | Req: REQUIRED
+RAZORPAY_WEBHOOK_SECRET=
+
 
 # -----------------------------------------------------------------------------
 # SSL / TLS (Server)


### PR DESCRIPTION
## Summary
- Follow-up to #114 (merged, PR #627). `.env.example` never documented `RAZORPAY_WEBHOOK_SECRET` at all, and #114 removed its `application.properties` default — a developer following `.env.example` alone would set `RAZORPAY_KEY_ID`/`RAZORPAY_KEY_SECRET` and still hit a startup failure from the undocumented, now-required third variable. Found while helping configure real Razorpay credentials post-merge.

## Test plan
- [x] Diff-only change to a documentation/template file (`.env.example`), no code path affected — verified by reading the file, no test applicable.