### PR TITLE
fix(ci): remove continue-on-error masking on E2E/Load Tests gates (#130)

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -331,8 +331,7 @@ jobs:
       
       - name: Run E2E tests
         run: ./mvnw test -P e2e-tests
-        continue-on-error: true
-      
+
       - name: Upload E2E test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -403,8 +402,7 @@ jobs:
       
       - name: Run Gatling load tests
         run: ./mvnw gatling:test
-        continue-on-error: true
-      
+
       - name: Upload Gatling reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
 
 ## [Unreleased] — M4: Feature Development
 
+### Fixed
+- Full regression / M5 gate audit (REG-01, #130): found the `E2E Tests` and
+  `Load Tests` CI jobs (`ci-cd-pipeline.yml`) both carried
+  `continue-on-error: true`, masking real failures — E2E's Selenium suite
+  times out because it targets the backend's own port for pages the separate
+  frontend SPA actually serves (root cause tracked in #630); Gatling load-test
+  assertions genuinely fail (#631). Removed both masks so the jobs report
+  true state. Also found #130's own acceptance criteria cite Playwright/k6,
+  neither of which exist in this pipeline (Selenium/Gatling are the real
+  tools) — tracked in #632. #130 remains open pending #630/#631.
+
 ### Security
 - Hardcoded-secrets audit (FR-PAY-05, #114): `application.properties`'
   `razorpay.key.secret`/`razorpay.webhook.secret` previously defaulted to


### PR DESCRIPTION
## Summary
Full regression audit for #130 (M5 production gate checklist) found two CI jobs silently masking real failures via `continue-on-error: true`:

- **E2E Tests** — Selenium suite times out because it navigates to the backend's own random port expecting server-rendered HTML; the actual frontend SPA is never started in that job (root cause tracked in #630)
- **Load Tests** — Gatling assertions genuinely fail with exit code 1 (root cause tracked in #631)

Also found: #130's own acceptance criteria cite Playwright/k6, neither of which exist in this repo (Selenium/Gatling are the real tools), and two more jobs (`OWASP dependency check`, `stress tests`) still carry the same masking pattern — tracked in #632.

This PR only removes the masking so these jobs report their true state going forward. It does not fix the underlying E2E/Gatling failures — those are the separately-scoped, larger fixes in #630/#631.

## Gate audit result for #130
| Criterion | Status |
|---|---|
| `mvnw verify` zero failures, coverage ≥70% | Pass (CI: Unit Tests + Integration Tests & Coverage green) |
| PIT mutation score ≥75% | Pass — 77.0% |
| E2E all scenarios pass | **Fail** — was masked, now honest, tracked in #630 |
| Load test P95 <200ms | **Fail** — was masked (Gatling not k6), now honest, tracked in #631 |
| OWASP ZAP zero Critical | **N/A — doesn't exist in this pipeline**, tracked in #632 |
| Secret scan zero findings | Pass |
| All CI green on master | Green only because of the masking now removed |

**#130 should not be closed as passing.** Recommend closing this PR's own scope (unmask the gates) while #130 stays open, blocked on #630/#631.

## Test plan
- [x] Confirmed both `continue-on-error: true` lines removed, no other lines touched (diff reviewed)
- [ ] Next push to this branch will show E2E Tests / Load Tests jobs genuinely red — expected, not a regression introduced by this PR
- [x] Security checklist run — no secrets/auth/input-handling touched, pure CI config

