### PR TITLE
fix(ci): start the app and fix wrong endpoints in the Gatling load-test job (#631)

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -382,25 +382,70 @@ jobs:
   load-tests:
     name: Load Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: integration-tests
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           cache: 'maven'
-      
+
       - name: Grant execute permissions to mvnw
         run: chmod +x ./mvnw
-      
+
+      - name: Start application (in-memory H2, real security config)
+        # #631: gatling:test only fires HTTP requests at an already-running server — it never
+        # starts one itself. Previously nothing here started the app, so every request failed
+        # with connection-refused and the Gatling assertions failed on every run (masked by
+        # continue-on-error until #130 removed that). Mirrors the e2e-tests job's own nohup +
+        # curl-readiness pattern below for the frontend preview server.
+        #
+        # Deliberately does NOT activate the `test` Spring profile: SecurityConfig is
+        # `@Profile("!test")` (it assumes a manually-`@Import`ed TestSecurityConfig in a real
+        # JUnit context), so `-Dspring-boot.run.profiles=test` here would boot with no
+        # AuthenticationManager bean at all and fail startup — verified locally. Instead,
+        # `useTestClasspath=true` puts the H2 driver (test-scoped dependency) on the run
+        # classpath, and the individual properties below are set explicitly via
+        # `spring-boot.run.arguments` so the app boots against H2 with the REAL security chain
+        # (JWT auth, CORS, rate limiting) and no external MySQL/Redis/ES dependency — closer to
+        # production behavior than the test-profile permissive config, which matters for a load
+        # test meant to exercise real auth-gated endpoints. `ddl-auto=create-drop` (not the
+        # default `validate`) because Hibernate's own generated H2 types don't always match
+        # Liquibase's MySQL-targeted changeset types (confirmed locally: `is_default` boolean
+        # column mismatch) — create-drop lets Hibernate regenerate the schema from the entity
+        # mappings after Liquibase runs, avoiding the mismatch.
+        run: |
+          ARGS="--spring.datasource.url=jdbc:h2:mem:testdb --spring.datasource.username=sa --spring.datasource.password= --spring.datasource.driver-class-name=org.h2.Driver --spring.jpa.hibernate.ddl-auto=create-drop --spring.sql.init.mode=never --spring.liquibase.default-schema=PUBLIC --spring.jpa.properties.hibernate.default_schema=PUBLIC --jwt.secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA== --razorpay.key.id=test_key_id --razorpay.key.secret=test_key_secret --razorpay.webhook.secret=test_webhook_secret"
+          nohup ./mvnw spring-boot:run \
+            -Dspring-boot.run.useTestClasspath=true \
+            -Dspring-boot.run.arguments="$ARGS" \
+            > app.log 2>&1 &
+          echo "Waiting for application to become ready..."
+          # /actuator/health/readiness (not /actuator/health) — overall health aggregates
+          # Redis/Elasticsearch/mail indicators, which are deliberately unreachable in this
+          # stripped-down environment and would keep the aggregate status DOWN forever even
+          # though the app itself is fully serving requests (verified locally).
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8080/actuator/health/readiness > /dev/null; then
+              echo "Application is up."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Application did not become ready in time:"
+          cat app.log
+          exit 1
+
       - name: Run Gatling load tests
+        # simulationClass pinned in pom.xml's gatling-maven-plugin config (#631) — LoadTestSimulation
+        # is the only simulation with real global assertions (response time + success rate).
         run: ./mvnw gatling:test
 
       - name: Upload Gatling reports
@@ -409,6 +454,13 @@ jobs:
         with:
           name: gatling-reports
           path: backend/target/gatling/
+
+      - name: Upload application log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-app-log
+          path: backend/app.log
 
   # Job 7: Stress Tests (Scheduled only)
   stress-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
 ## [Unreleased] — M4: Feature Development
 
 ### Fixed
+- Gatling load-test CI job genuinely failing (#631, found via #130's regression
+  audit): the `load-tests` job (`ci-cd-pipeline.yml`) ran `./mvnw gatling:test`
+  with nothing ever starting the Spring Boot app first — every HTTP call hit
+  connection-refused against `localhost:8080`. Added an app-startup step
+  (in-memory H2, real `SecurityConfig` rather than the permissive `test`
+  profile, since `SecurityConfig` is `@Profile("!test")`) with a
+  `/actuator/health/readiness` readiness check, mirroring the `e2e-tests`
+  job's own nohup + curl-readiness pattern. Also fixed `LoadTestSimulation.java`,
+  which independently targeted nonexistent/wrong endpoints regardless of
+  whether the server was reachable — `/api/products` and `/api/products/{id}`
+  don't exist (real public routes are under `/api/public/products`); the
+  search query param is `keyword`, not `q`; `LoginRequest`'s field is
+  `username`, not `email`; `/api/cart/items` doesn't exist (real route is
+  `/api/user/cart/add`); an unauthenticated cart-add returns 403 via
+  `@PreAuthorize`, not 401. Pinned `gatling-maven-plugin`'s `simulationClass`
+  to `LoadTestSimulation` (the only one of 4 simulation classes with real
+  global assertions) to avoid non-deterministic selection in non-interactive
+  CI. Verified locally: all 4 scenarios pass against a real running instance
+  (100% success, max response time 472ms < 5000ms threshold).
+
 - Full regression / M5 gate audit (REG-01, #130): found the `E2E Tests` and
   `Load Tests` CI jobs (`ci-cd-pipeline.yml`) both carried
   `continue-on-error: true`, masking real failures — E2E's Selenium suite

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -732,10 +732,18 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<!-- Gatling Maven Plugin for load testing -->
+			<!-- simulationClass pinned to LoadTestSimulation: it's the only simulation with real
+			     global assertions (response time + success rate); the 3 sibling Scala simulations
+			     under src/test/scala/simulations have no assertions of their own. Without this,
+			     gatling:test with multiple simulation classes on the classpath is non-deterministic
+			     in non-interactive CI (#631). -->
 			<plugin>
 				<groupId>io.gatling</groupId>
 				<artifactId>gatling-maven-plugin</artifactId>
 				<version>4.7.0</version>
+				<configuration>
+					<simulationClass>com.example.buildnest_ecommerce.loadtest.LoadTestSimulation</simulationClass>
+				</configuration>
 			</plugin>
 			<!-- OWASP Dependency-Check Plugin (Mitigation #6: Security scanning) -->
 			<plugin>

--- a/backend/src/test/java/com/example/buildnest_ecommerce/loadtest/LoadTestSimulation.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/loadtest/LoadTestSimulation.java
@@ -36,14 +36,16 @@ public class LoadTestSimulation extends Simulation {
                         .userAgentHeader("Gatling Load Test");
 
         // Scenario: Browse Products (TC-LOAD-001)
+        // #631: /api/products and /api/products/{id} don't exist in this codebase — the real
+        // unauthenticated product-browsing routes are under /api/public/products (HomeController).
         ChainBuilder browseProductsChain = exec(
                         http("Get Products List")
-                                        .get("/api/products")
+                                        .get("/api/public/products")
                                         .check(status().is(200)))
                         .pause(Duration.ofSeconds(2))
                         .exec(
                                         http("Get Product Details")
-                                                        .get("/api/products/1")
+                                                        .get("/api/public/products/1")
                                                         .check(status().in(200, 404)))
                         .pause(Duration.ofSeconds(1));
 
@@ -51,9 +53,10 @@ public class LoadTestSimulation extends Simulation {
                         .exec(browseProductsChain);
 
         // Scenario: Search Products (TC-LOAD-002)
+        // #631: query param is `keyword`, not `q` (see HomeController#searchProducts).
         ChainBuilder searchProductsChain = exec(
                         http("Search Products")
-                                        .get("/api/products/search?q=cement")
+                                        .get("/api/public/products/search?keyword=cement")
                                         .check(status().is(200)))
                         .pause(Duration.ofSeconds(2));
 
@@ -61,31 +64,37 @@ public class LoadTestSimulation extends Simulation {
                         .exec(searchProductsChain);
 
         // Scenario: Authentication Flow (TC-LOAD-003)
+        // #631: LoginRequest's field is `username` (see LoginRequest.java), not `email`; an
+        // invalid-credentials login returns 400 (AuthController), not 401 — verified locally.
         ChainBuilder authenticationChain = exec(
                         http("Login Request")
                                         .post("/api/auth/login")
                                         .header("Content-Type", "application/json")
                                         .body(StringBody("""
                                                         {
-                                                            "email": "test@example.com",
+                                                            "username": "test@example.com",
                                                             "password": "password123"
                                                         }
                                                         """))
-                                        .check(status().in(200, 401)))
+                                        .check(status().in(200, 400)))
                         .pause(Duration.ofSeconds(3));
 
         ScenarioBuilder authenticationScenario = scenario("User Authentication")
                         .exec(authenticationChain);
 
         // Scenario: Add to Cart (TC-LOAD-004)
+        // #631: real route is /api/user/cart/add (see CartController); /api/cart/items doesn't
+        // exist. An unauthenticated request here is rejected by @PreAuthorize (anonymous
+        // principal fails the role/ownership check) as 403, not the 401 an AuthenticationEntryPoint
+        // would return — verified locally against the real filter chain.
         ChainBuilder addToCartChain = exec(
                         http("View Products")
-                                        .get("/api/products")
+                                        .get("/api/public/products")
                                         .check(status().is(200)))
                         .pause(Duration.ofSeconds(1))
                         .exec(
                                         http("Add to Cart")
-                                                        .post("/api/cart/items")
+                                                        .post("/api/user/cart/add")
                                                         .header("Content-Type", "application/json")
                                                         .body(StringBody("""
                                                                         {
@@ -93,7 +102,7 @@ public class LoadTestSimulation extends Simulation {
                                                                             "quantity": 2
                                                                         }
                                                                         """))
-                                                        .check(status().in(200, 201, 401)))
+                                                        .check(status().in(200, 201, 403)))
                         .pause(Duration.ofSeconds(2));
 
         ScenarioBuilder addToCartScenario = scenario("Add to Cart")


### PR DESCRIPTION
## Summary
- The `load-tests` CI job (`ci-cd-pipeline.yml`) ran `./mvnw gatling:test` with no step ever starting the Spring Boot app — every request hit connection-refused. Added an app-startup step (in-memory H2, real `SecurityConfig` — not the permissive `test` profile, which is `@Profile("!test")`-excluded) with a `/actuator/health/readiness` readiness check, mirroring the `e2e-tests` job's own nohup+curl pattern.
- `LoadTestSimulation.java` independently targeted wrong/nonexistent endpoints regardless of server availability: `/api/products`/`/api/products/{id}` don't exist (real public routes are `/api/public/products`); search param is `keyword` not `q`; `LoginRequest`'s field is `username` not `email`; `/api/cart/items` doesn't exist (`/api/user/cart/add` is real); unauthenticated cart-add returns 403 via `@PreAuthorize`, not 401.
- Pinned `gatling-maven-plugin`'s `simulationClass` to `LoadTestSimulation` (the only simulation with real global assertions) to remove non-deterministic selection among 4 simulation classes in non-interactive CI.

## Test plan
- [x] Compiled main + test sources locally (`mvn compile`, `mvn test-compile`)
- [x] Started the real app locally against in-memory H2 with the exact CI command, verified `/actuator/health/readiness` returns 200
- [x] Verified each fixed endpoint returns the expected status code (200/404/403) against a real running instance
- [x] Ran `./mvnw gatling:test` locally against the running instance — **100% success (100/100 requests), max response time 472ms < 5000ms threshold** — both global assertions pass
- [ ] CI: `load-tests` job runs on push to `master`/`main` only (not on PRs) — final confirmation is a real CI run post-merge, per this repo's tier-0 empirical-verification rule for CI-config changes

Closes #631

https://claude.ai/code/session_01S2kw8AK3qe6G6pLieAgX15