### PR TITLE
fix(test): bootstrap CSRF token/header in RestAssured e2e tests (#635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
 ## [Unreleased] — M4: Feature Development
 
 ### Fixed
+- `CartApiTest`/`OrderApiTest`/`ProductApiTest` receiving `403` on every
+  mutating request (#635, discovered via #630's own audit but a separate,
+  unrelated root cause): these RestAssured-based tests never fetched the
+  `XSRF-TOKEN` cookie or echoed it as `X-XSRF-TOKEN`, required for every
+  non-exempt mutating endpoint since CSRF protection was enabled (SEC-15).
+  `BaseApiTest.setup()` now bootstraps via `GET /api/auth/csrf` and applies
+  the cookie/header as RestAssured request-spec defaults. `CartApiTest` now
+  passes fully; fixing this uncovered two separate, pre-existing defects only
+  reachable once tests get past the CSRF wall — `OrderApiTest.testCheckoutProcess`
+  StackOverflowError (#638) and `ProductApiTest`'s `GET /api/v2/products` 500
+  (#639) — tracked as independent follow-ups, not fixed in this change.
 - Gatling load-test CI job genuinely failing (#631, found via #130's regression
   audit): the `load-tests` job (`ci-cd-pipeline.yml`) ran `./mvnw gatling:test`
   with nothing ever starting the Spring Boot app first — every HTTP call hit

--- a/backend/src/test/java/com/example/buildnest_ecommerce/e2e/BaseApiTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/e2e/BaseApiTest.java
@@ -49,6 +49,23 @@ public abstract class BaseApiTest {
     public void setup() {
         RestAssured.port = port;
         RestAssured.baseURI = "http://localhost";
+
+        // SEC-15: CSRF protection is enabled for every non-exempt mutating endpoint (see
+        // spring-security.md). A real browser fetches XSRF-TOKEN and echoes it as
+        // X-XSRF-TOKEN automatically; RestAssured does not, so every mutating request in
+        // this suite was receiving 403 until this bootstrap was added (#635).
+        String csrfToken = RestAssured.given()
+                .when()
+                .get("/api/auth/csrf")
+                .then()
+                .statusCode(204)
+                .extract()
+                .cookie("XSRF-TOKEN");
+
+        RestAssured.requestSpecification = new io.restassured.builder.RequestSpecBuilder()
+                .addCookie("XSRF-TOKEN", csrfToken)
+                .addHeader("X-XSRF-TOKEN", csrfToken)
+                .build();
     }
 
     protected String getAuthToken() {

--- a/backend/src/test/java/com/example/buildnest_ecommerce/e2e/BaseApiTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/e2e/BaseApiTest.java
@@ -54,6 +54,15 @@ public abstract class BaseApiTest {
         // spring-security.md). A real browser fetches XSRF-TOKEN and echoes it as
         // X-XSRF-TOKEN automatically; RestAssured does not, so every mutating request in
         // this suite was receiving 403 until this bootstrap was added (#635).
+        //
+        // RestAssured.given() merges the static RestAssured.requestSpecification set
+        // below, so on the 2nd+ test class in the same JVM this bootstrap call would
+        // otherwise carry the *previous* class's already-valid XSRF-TOKEN cookie.
+        // NonClearingCsrfTokenRepository (and CookieCsrfTokenRepository generally) skips
+        // re-emitting Set-Cookie when the incoming cookie already matches the resolved
+        // token, so .cookie("XSRF-TOKEN") on that response finds nothing new. Clearing
+        // the static spec first forces a clean request and a genuinely fresh cookie.
+        RestAssured.requestSpecification = null;
         String csrfToken = RestAssured.given()
                 .when()
                 .get("/api/auth/csrf")


### PR DESCRIPTION
## Summary
- `CartApiTest`/`OrderApiTest`/`ProductApiTest` sent mutating RestAssured requests without fetching `XSRF-TOKEN` or echoing `X-XSRF-TOKEN`, required for every non-exempt endpoint since SEC-15 enabled CSRF protection. `BaseApiTest.setup()` now bootstraps via `GET /api/auth/csrf` and applies the cookie/header as RestAssured request-spec defaults.
- `CartApiTest` now passes fully (1/1, 0 failures/errors, confirmed in isolation).
- Fixing the CSRF wall exposed two separate, pre-existing, unrelated defects only reachable once requests get past 403 for the first time — tracked as independent follow-ups, **not** fixed in this PR:
  - #638 — `OrderApiTest.testCheckoutProcess` `StackOverflowError` in the JSON response parser
  - #639 — `ProductApiTest`'s `GET /api/v2/products` genuine `500` (pagination + collection-fetch)

## Scope note — does NOT close #635
#635's own acceptance criteria require "CartApiTest, OrderApiTest, ProductApiTest all pass" and "E2E Tests CI job goes fully green." Those won't be satisfied until #638/#639 also land, since their root causes are unrelated to CSRF. The CSRF-bootstrap fix itself (this issue's named defect) is complete and verified — but #635 should stay open, tracking the two blocking follow-ups, rather than auto-closing on this merge.

## Test plan
- [x] `mvn test -P e2e-tests -Dtest=CartApiTest` — 1/1 pass, 0 failures/errors
- [x] Confirmed no more `403` anywhere in `OrderApiTest`/`ProductApiTest` runs (CSRF fix itself works for all three classes)
- [ ] `OrderApiTest`/`ProductApiTest` full green — blocked on #638/#639

Progress on #635 (does not close it — see scope note above)