### PR TITLE
fix(checkout): return OrderResponseDTO instead of raw Order entity (#638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
 ## [Unreleased] — M4: Feature Development
 
 ### Fixed
+- `OrderApiTest.testCheckoutProcess` `StackOverflowError` (#638, discovered
+  via #635's own CSRF fix uncovering it): `CheckoutController.processCheckout()`/
+  `processCheckoutWithPayment()` returned the raw `Order` JPA entity directly,
+  violating `spring/jpa.md`'s "never return a JPA entity from a controller"
+  rule — `Order.orderItems`/`OrderItem.order` form a bidirectional cycle with
+  no `@JsonIgnore`, so Jackson serialization never terminated cleanly and
+  RestAssured's client-side JSON parser overflowed trying to parse the
+  malformed response. `CheckoutService.checkoutCart()`/`checkoutWithPayment()`
+  now return `OrderResponseDTO`, mapped via the same class's own existing
+  `toOrderDTO()` helper (already used by `confirmCheckout()`). `OrderApiTest`
+  now 3/3 pass.
 - `CartApiTest`/`OrderApiTest`/`ProductApiTest` receiving `403` on every
   mutating request (#635, discovered via #630's own audit but a separate,
   unrelated root cause): these RestAssured-based tests never fetched the

--- a/backend/src/main/java/com/example/buildnest_ecommerce/controller/user/CheckoutController.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/controller/user/CheckoutController.java
@@ -1,7 +1,7 @@
 package com.example.buildnest_ecommerce.controller.user;
 
 import com.example.buildnest_ecommerce.model.dto.CheckoutRequestDTO;
-import com.example.buildnest_ecommerce.model.entity.Order;
+import com.example.buildnest_ecommerce.model.dto.OrderResponseDTO;
 import com.example.buildnest_ecommerce.model.payload.ApiResponse;
 import com.example.buildnest_ecommerce.service.checkout.CheckoutService;
 import com.example.buildnest_ecommerce.security.CustomUserDetails;
@@ -29,34 +29,50 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/checkout")
 @RequiredArgsConstructor
 @Slf4j
-@Tag(name = "Checkout", description = "Endpoints for cart checkout and order processing")
+@Tag(name = "Checkout",
+        description = "Endpoints for cart checkout and order processing")
 @SecurityRequirement(name = "Bearer Authentication")
 public class CheckoutController {
 
     private final CheckoutService checkoutService;
 
-    @Operation(summary = "Process checkout", description = "Convert a shopping cart into an order. Validates cart, checks inventory, and creates order.", tags = {
-            "Checkout" })
+    @Operation(summary = "Process checkout",
+            description = "Convert a shopping cart into an order. "
+                    + "Validates cart, checks inventory, and creates order.",
+            tags = { "Checkout" })
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Order created successfully", content = @Content(schema = @Schema(implementation = Order.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid cart or insufficient inventory"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Internal server error during checkout")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "Order created successfully",
+                    content = @Content(schema = @Schema(
+                            implementation = OrderResponseDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid cart or insufficient inventory"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "Internal server error during checkout")
     })
     @PostMapping("/process/{cartId}")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse> processCheckout(
-            @Parameter(description = "Cart ID to checkout", example = "1", required = true) @PathVariable Long cartId,
+            @Parameter(description = "Cart ID to checkout", example = "1",
+                    required = true) @PathVariable Long cartId,
             Authentication authentication) {
         try {
-            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            CustomUserDetails userDetails =
+                    (CustomUserDetails) authentication.getPrincipal();
             Long userId = userDetails.getId();
 
-            log.info("Processing checkout for user: {}, cart: {}", userId, cartId);
+            log.info("Processing checkout for user: {}, cart: {}",
+                    userId, cartId);
 
-            Order order = checkoutService.checkoutCart(userId, cartId);
+            OrderResponseDTO order =
+                    checkoutService.checkoutCart(userId, cartId);
 
             return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(new ApiResponse(true, "Order placed successfully", order));
+                    .body(new ApiResponse(
+                            true, "Order placed successfully", order));
         } catch (IllegalArgumentException e) {
             log.error("Invalid checkout attempt: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -64,7 +80,9 @@ public class CheckoutController {
         } catch (Exception e) {
             log.error("Error processing checkout", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ApiResponse(false, "Error processing checkout: " + e.getMessage(), null));
+                    .body(new ApiResponse(false,
+                            "Error processing checkout: " + e.getMessage(),
+                            null));
         }
     }
 
@@ -75,16 +93,21 @@ public class CheckoutController {
             @Valid @RequestBody CheckoutRequestDTO request,
             Authentication authentication) {
         try {
-            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            CustomUserDetails userDetails =
+                    (CustomUserDetails) authentication.getPrincipal();
             Long userId = userDetails.getId();
 
-            log.info("Processing checkout with payment for user: {}, cart: {}", userId, cartId);
+            log.info("Processing checkout with payment for user: {}, "
+                    + "cart: {}", userId, cartId);
 
-            Order order = checkoutService.checkoutWithPayment(userId, cartId, request);
+            OrderResponseDTO order = checkoutService.checkoutWithPayment(
+                    userId, cartId, request);
 
             return ResponseEntity.status(HttpStatus.CREATED)
                     .body(new ApiResponse(true,
-                            "Order placed successfully with payment method: " + request.getPaymentMethod(), order));
+                            "Order placed successfully with payment "
+                                    + "method: " + request.getPaymentMethod(),
+                            order));
         } catch (IllegalArgumentException e) {
             log.error("Invalid checkout attempt: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -92,7 +115,9 @@ public class CheckoutController {
         } catch (Exception e) {
             log.error("Error processing checkout with payment", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ApiResponse(false, "Error processing checkout: " + e.getMessage(), null));
+                    .body(new ApiResponse(false,
+                            "Error processing checkout: " + e.getMessage(),
+                            null));
         }
     }
 
@@ -102,37 +127,45 @@ public class CheckoutController {
             @PathVariable Long cartId,
             Authentication authentication) {
         try {
-            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            CustomUserDetails userDetails =
+                    (CustomUserDetails) authentication.getPrincipal();
             Long userId = userDetails.getId();
 
-            log.debug("Validating checkout for user: {}, cart: {}", userId, cartId);
+            log.debug("Validating checkout for user: {}, cart: {}",
+                    userId, cartId);
 
-            boolean isValid = checkoutService.validateCheckout(userId, cartId);
+            boolean isValid =
+                    checkoutService.validateCheckout(userId, cartId);
 
             return ResponseEntity.ok(new ApiResponse(true,
-                    isValid ? "Cart is ready for checkout" : "Cart is not ready for checkout",
+                    isValid ? "Cart is ready for checkout"
+                            : "Cart is not ready for checkout",
                     isValid));
         } catch (Exception e) {
             log.error("Error validating checkout", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ApiResponse(false, "Error validating checkout", null));
+                    .body(new ApiResponse(
+                            false, "Error validating checkout", null));
         }
     }
 
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/calculate-total/{cartId}")
-    public ResponseEntity<ApiResponse> calculateTotal(@PathVariable Long cartId) {
+    public ResponseEntity<ApiResponse> calculateTotal(
+            @PathVariable Long cartId) {
         try {
             log.debug("Calculating final total for cart: {}", cartId);
 
             Double finalTotal = checkoutService.calculateFinalTotal(cartId);
 
-            return ResponseEntity.ok(new ApiResponse(true, "Total calculated successfully",
+            return ResponseEntity.ok(new ApiResponse(true,
+                    "Total calculated successfully",
                     new CartTotalDTO(finalTotal)));
         } catch (Exception e) {
             log.error("Error calculating total", e);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new ApiResponse(false, "Error calculating total", null));
+                    .body(new ApiResponse(
+                            false, "Error calculating total", null));
         }
     }
 

--- a/backend/src/main/java/com/example/buildnest_ecommerce/service/checkout/CheckoutService.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/service/checkout/CheckoutService.java
@@ -3,7 +3,6 @@ package com.example.buildnest_ecommerce.service.checkout;
 import com.example.buildnest_ecommerce.model.dto.CheckoutRequestDTO;
 import com.example.buildnest_ecommerce.model.dto.CheckoutSessionDTO;
 import com.example.buildnest_ecommerce.model.dto.OrderResponseDTO;
-import com.example.buildnest_ecommerce.model.entity.Order;
 
 public interface CheckoutService {
 
@@ -29,18 +28,21 @@ public interface CheckoutService {
      * Process checkout and create order from cart
      * @param userId User performing checkout
      * @param cartId Cart to checkout
-     * @return Created Order
+     * @return Created order, mapped to a DTO — never return the raw JPA
+     *         entity here (Order.orderItems / OrderItem.order form a
+     *         bidirectional cycle Jackson can't safely serialize, #638)
      */
-    Order checkoutCart(Long userId, Long cartId);
-    
+    OrderResponseDTO checkoutCart(Long userId, Long cartId);
+
     /**
      * Process checkout with payment method
      * @param userId User performing checkout
      * @param cartId Cart to checkout
      * @param request Checkout details including payment method
-     * @return Created Order
+     * @return Created order, mapped to a DTO — see {@link #checkoutCart}
      */
-    Order checkoutWithPayment(Long userId, Long cartId, CheckoutRequestDTO request);
+    OrderResponseDTO checkoutWithPayment(
+            Long userId, Long cartId, CheckoutRequestDTO request);
     
     /**
      * Validate if cart is ready for checkout

--- a/backend/src/main/java/com/example/buildnest_ecommerce/service/checkout/CheckoutServiceImpl.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/service/checkout/CheckoutServiceImpl.java
@@ -479,7 +479,7 @@ public class CheckoutServiceImpl implements CheckoutService {
 
     @Override
     @Transactional
-    public Order checkoutCart(Long userId, Long cartId) {
+    public OrderResponseDTO checkoutCart(Long userId, Long cartId) {
         log.info("Starting checkout for user: {} with cart: {}",
                 userId, cartId);
 
@@ -515,12 +515,12 @@ public class CheckoutServiceImpl implements CheckoutService {
         log.info("Checkout completed for user: {}, Order ID: {}, "
                         + "sellerOrderCount={}",
                 userId, primary.getId(), orders.size());
-        return primary;
+        return toOrderDTO(primary);
     }
 
     @Override
     @Transactional
-    public Order checkoutWithPayment(
+    public OrderResponseDTO checkoutWithPayment(
             Long userId, Long cartId, CheckoutRequestDTO request) {
         log.info("Starting checkout with payment for user: {} with "
                 + "cart: {}", userId, cartId);
@@ -552,7 +552,7 @@ public class CheckoutServiceImpl implements CheckoutService {
         log.info("Checkout with payment completed. Order ID: {}, "
                         + "sellerOrderCount={}",
                 primary.getId(), savedOrders.size());
-        return primary;
+        return toOrderDTO(primary);
     }
 
     @Override

--- a/backend/src/test/java/com/example/buildnest_ecommerce/controller/user/CheckoutControllerTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/controller/user/CheckoutControllerTest.java
@@ -3,7 +3,7 @@ package com.example.buildnest_ecommerce.controller.user;
 import com.example.buildnest_ecommerce.config.TestElasticsearchConfig;
 import com.example.buildnest_ecommerce.config.TestSecurityConfig;
 import com.example.buildnest_ecommerce.model.dto.CheckoutRequestDTO;
-import com.example.buildnest_ecommerce.model.entity.Order;
+import com.example.buildnest_ecommerce.model.dto.OrderResponseDTO;
 import com.example.buildnest_ecommerce.security.CustomUserDetails;
 import com.example.buildnest_ecommerce.service.checkout.CheckoutService;
 import com.example.buildnest_ecommerce.service.ratelimit.RateLimiterService;
@@ -94,7 +94,7 @@ class CheckoutControllerTest {
                 request.setPhoneNumber("+14155552671");
                 request.setQuantity(2);
 
-                Order order = new Order();
+                OrderResponseDTO order = new OrderResponseDTO();
                 order.setId(10L);
                 order.setTotalAmount(new BigDecimal("5000.00"));
 
@@ -109,7 +109,7 @@ class CheckoutControllerTest {
 
         @Test
         void testProcessCheckoutValid() throws Exception {
-                Order order = new Order();
+                OrderResponseDTO order = new OrderResponseDTO();
                 order.setId(20L);
                 order.setTotalAmount(new BigDecimal("1500.00"));
 
@@ -182,7 +182,7 @@ class CheckoutControllerTest {
                 request.setPhoneNumber("+14155552671");
                 request.setQuantity(5);
 
-                Order order = new Order();
+                OrderResponseDTO order = new OrderResponseDTO();
                 order.setId(11L);
                 order.setTotalAmount(new BigDecimal("99999999.00"));
 

--- a/backend/src/test/java/com/example/buildnest_ecommerce/service/checkout/CheckoutServiceImplTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/service/checkout/CheckoutServiceImplTest.java
@@ -128,7 +128,7 @@ class CheckoutServiceImplTest {
             return orders;
         });
 
-        Order order = checkoutService.checkoutCart(1L, 10L);
+        OrderResponseDTO order = checkoutService.checkoutCart(1L, 10L);
         assertNotNull(order.getId());
 
         ArgumentCaptor<List<Order>> orderCaptor = ArgumentCaptor.forClass(List.class);
@@ -173,7 +173,8 @@ class CheckoutServiceImplTest {
             return orders;
         });
 
-        Order order = checkoutService.checkoutWithPayment(1L, 10L, new CheckoutRequestDTO());
+        OrderResponseDTO order = checkoutService.checkoutWithPayment(
+                1L, 10L, new CheckoutRequestDTO());
         assertNotNull(order.getId());
 
         ArgumentCaptor<List<Order>> orderCaptor = ArgumentCaptor.forClass(List.class);
@@ -906,7 +907,7 @@ class CheckoutServiceImplTest {
             return orders;
         });
 
-        Order primary = checkoutService.checkoutCart(1L, 10L);
+        OrderResponseDTO primary = checkoutService.checkoutCart(1L, 10L);
 
         verify(orderGroupRepository).save(any(OrderGroup.class));
         ArgumentCaptor<List<Order>> orderCaptor = ArgumentCaptor.forClass(List.class);
@@ -914,7 +915,7 @@ class CheckoutServiceImplTest {
         List<Order> saved = orderCaptor.getValue();
 
         assertEquals(2, saved.size(), "one order per seller");
-        assertEquals(saved.get(0), primary,
+        assertEquals(saved.get(0).getId(), primary.getId(),
                 "primary order returned is the first seller-group order");
         for (Order order : saved) {
             assertEquals(savedGroup, order.getOrderGroup(),


### PR DESCRIPTION
## Summary
- `CheckoutController.processCheckout()`/`processCheckoutWithPayment()` both returned the raw `Order` JPA entity directly, violating `spring/jpa.md`'s "never return a JPA entity from a controller" rule.
- `Order.orderItems` (`Set<OrderItem>`) and `OrderItem.order` form a bidirectional cycle with no `@JsonIgnore` anywhere — Jackson serialization never terminated cleanly, producing a malformed/oversized response that overflowed RestAssured's client-side JSON parser stack (`OrderApiTest.testCheckoutProcess`).
- `CheckoutService.checkoutCart()`/`checkoutWithPayment()` now return `OrderResponseDTO`, mapped via `CheckoutServiceImpl`'s own existing `toOrderDTO()` helper (already used by `confirmCheckout()` — a direct, single-precedent mirror, no new mapping logic).

## Test plan
- [x] `OrderApiTest` (`testCheckoutProcess`, `testGetOrderHistory`, `testGetOrderDetails`) — 3/3 pass, was StackOverflowError before this fix
- [x] `CartApiTest` — still 1/1 pass (unaffected)
- [x] `CheckoutServiceImplTest`/`CheckoutControllerTest` — full suite pass after updating 2 test files' mocks/assertions for the new return type
- [x] Full backend compile clean

`ProductApiTest`'s separate #639 bug is unaffected by this change (still 5/5 failing, tracked independently).

Closes #638