### PR TITLE
fix(security): suppress false-positive netty CVE-2026-56816

### DIFF
--- a/backend/owasp-suppressions.xml
+++ b/backend/owasp-suppressions.xml
@@ -132,4 +132,26 @@
         <packageUrl regex="true">^pkg:maven/io\.netty/.*@.*$</packageUrl>
         <cve>CVE-2026-42582</cve>
     </suppress>
+
+    <!-- Issue #636: io.netty:* 4.1.136.Final family (CVE-2026-56816, 7.5 HIGH) — CONFIRMED
+         FALSE POSITIVE, verified directly against the NVD detail page on 2026-08-01. The
+         vulnerability is in Http3FrameCodec.decodeFrame (io.netty.handler.codec.http3), which
+         buffers incoming HTTP/3 reserved-frame payloads up to the wire-specified length without
+         limits, allowing memory-exhaustion DoS via multiple QUIC streams with oversized reserved
+         frames. Http3FrameCodec lives in netty-codec-http3, a 4.2.x-era module for HTTP/3/QUIC
+         support that does not exist in the 4.1.x release line at all — confirmed via
+         `mvnw dependency:tree`, which shows zero http3/quic artifacts anywhere in this project's
+         resolved dependency graph. This project is pinned to netty 4.1.136.Final (see
+         netty.version above, from #332/CVE-2026-42582), so the vulnerable component is not
+         merely unpatched but structurally absent from what is shipped — same false-positive
+         shape (a 4.2.x-only HTTP/3 codec module misapplied against the whole io.netty groupId
+         CPE) as the existing CVE-2026-42582 suppression immediately above. See issue #636. -->
+    <suppress>
+        <notes>Confirmed false positive, verified against NVD directly — CVE-2026-56816 only
+        affects Http3FrameCodec in netty-codec-http3 (HTTP/3/QUIC support, a 4.2.x-only module);
+        this project is on netty 4.1.136.Final and has no http3/quic artifacts anywhere in its
+        dependency tree (confirmed via `mvnw dependency:tree`). See issue #636.</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/.*@.*$</packageUrl>
+        <cve>CVE-2026-56816</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary
- OWASP Dependency-Check (`ci.yml`) flags `CVE-2026-56816` (CVSS 7.5) against `netty-transport-4.1.136.Final.jar`, surfaced while working #630/PR #634 (unrelated to that branch's own diff).
- Verified directly against NVD: the vulnerability is in `Http3FrameCodec.decodeFrame` (`io.netty.handler.codec.http3`), a 4.2.x-only HTTP/3/QUIC module. This project is pinned to netty `4.1.136.Final` and has zero `http3`/`quic` artifacts anywhere in its resolved dependency tree (`mvnw dependency:tree` confirms this) — the vulnerable component is structurally absent, not just unpatched.
- Same false-positive shape as the existing `CVE-2026-42582` suppression already in `owasp-suppressions.xml` (a 4.2.x-only HTTP/3 codec CPE misapplied against the whole `io.netty` groupId). Added a matching suppression entry with full NVD-verification notes.

## Test plan
- [x] Verified `netty-transport` version in use (`4.1.136.Final`) via `pom.xml`/`dependency:tree`
- [x] Verified NVD detail page for CVE-2026-56816 directly (not just CPE match)
- [x] Confirmed zero `http3`/`quic` artifacts in the dependency tree
- [ ] `OWASP Dependency-Check` CI job goes green on this PR (empirical verification — will watch the real run)

Closes #636