### PR TITLE
fix(security): add Referrer-Policy and Permissions-Policy headers (SEC-16, #112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,23 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
   tools) — tracked in #632. #130 remains open pending #630/#631.
 
 ### Security
+- HTTP security headers audit and enforcement (SEC-11/SEC-12, #112): audited
+  the 5 headers named in the issue's acceptance criteria against the Spring
+  Security 6.5 reference docs (verified via context7, not assumed from
+  memory). HSTS (`max-age=31536000; includeSubDomains`), X-Frame-Options
+  (`DENY`), and X-Content-Type-Options (`nosniff`) were already correctly
+  configured/covered by existing tests. Referrer-Policy and Permissions-Policy
+  were genuinely missing — Spring Security does not add either by default
+  (confirmed against the docs, not assumed). Added
+  `SecurityHeaderPolicies.REFERRER_POLICY`
+  (`strict-origin-when-cross-origin`) and `PERMISSIONS_POLICY` (denies
+  geolocation/camera/microphone/payment/usb outright — none of these
+  browser features are used server-side or in the SPA), wired into both
+  `SecurityConfig`'s main chain and `TestSecurityConfig`'s test-profile
+  stand-in via the same shared-constants pattern #312 already established
+  for CSP/HSTS, so the two configs cannot drift apart. `SecurityHeadersTest`
+  extended with 3 new assertions (nosniff, Referrer-Policy,
+  Permissions-Policy) — 5/5 pass.
 - Hardcoded-secrets audit (FR-PAY-05, #114): `application.properties`'
   `razorpay.key.secret`/`razorpay.webhook.secret` previously defaulted to
   known values (`test_key_secret`/`test_webhook_secret`) that also applied

--- a/backend/src/main/java/com/example/buildnest_ecommerce/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/config/SecurityConfig.java
@@ -284,7 +284,16 @@ public class SecurityConfig {
                                 .includeSubDomains(true)
                                 .preload(true)
                                 .maxAgeInSeconds(SecurityHeaderPolicies
-                                        .HSTS_MAX_AGE_SECONDS)))
+                                        .HSTS_MAX_AGE_SECONDS))
+                        .referrerPolicy(referrer -> referrer
+                                .policy(org.springframework.security.web
+                                        .header.writers
+                                        .ReferrerPolicyHeaderWriter
+                                        .ReferrerPolicy
+                                        .STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                        .permissionsPolicy(permissions -> permissions
+                                .policy(SecurityHeaderPolicies
+                                        .PERMISSIONS_POLICY)))
                 .cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration corsConfig = new CorsConfiguration();
                     // Allow specific origins in production (RQ-SEC-03 -

--- a/backend/src/main/java/com/example/buildnest_ecommerce/config/SecurityHeaderPolicies.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/config/SecurityHeaderPolicies.java
@@ -1,32 +1,60 @@
 package com.example.buildnest_ecommerce.config;
 
 /**
- * Single source of truth for the CSP directives enforced by {@link SecurityConfig}'s two
- * filter chains, and the shared HSTS max-age.
+ * Single source of truth for the CSP directives enforced by
+ * {@link SecurityConfig}'s two filter chains, and the shared HSTS max-age.
  *
- * <p>{@code SecurityConfig} never loads during a test run (it is {@code @Profile("!test")}),
- * so {@code TestSecurityConfig} (the test-profile stand-in) previously hand-duplicated the CSP
- * policy string and had drifted from it silently — the production hardening from #237 had zero
- * regression coverage as a result (#312). Both classes now reference these constants so the two
- * configurations cannot drift apart again without a compile error at the reference site.
+ * <p>{@code SecurityConfig} never loads during a test run (it is
+ * {@code @Profile("!test")}), so {@code TestSecurityConfig} (the
+ * test-profile stand-in) previously hand-duplicated the CSP policy string
+ * and had drifted from it silently — the production hardening from #237
+ * had zero regression coverage as a result (#312). Both classes now
+ * reference these constants so the two configurations cannot drift apart
+ * again without a compile error at the reference site.
  */
 public final class SecurityHeaderPolicies {
 
-    /** Main-chain policy: all {@code /api/**} paths. No {@code unsafe-inline} — see #237. */
+    /**
+     * Main-chain policy: all {@code /api/**} paths. No
+     * {@code unsafe-inline} — see #237.
+     */
     public static final String MAIN_CSP =
             "default-src 'self'; script-src 'self'; style-src 'self'; " +
             "frame-ancestors 'none'; form-action 'self'";
 
     /**
-     * Swagger-chain policy: isolated to {@code /swagger-ui/**}, {@code /v3/api-docs/**} only.
-     * Retains {@code unsafe-inline}, which SpringDoc requires to render its bundled inline
-     * scripts and styles — never apply this policy outside the Swagger-specific filter chain.
+     * Swagger-chain policy: isolated to {@code /swagger-ui/**},
+     * {@code /v3/api-docs/**} only. Retains {@code unsafe-inline}, which
+     * SpringDoc requires to render its bundled inline scripts and styles
+     * — never apply this policy outside the Swagger-specific filter chain.
      */
     public static final String SWAGGER_CSP =
             "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
             "style-src 'self' 'unsafe-inline'; img-src 'self' data:";
 
     public static final long HSTS_MAX_AGE_SECONDS = 31536000L;
+
+    /**
+     * Referrer-Policy is not enabled by Spring Security's default headers
+     * (SEC-11/SEC-12, #112) — verified against the Spring Security 6.5
+     * reference docs, which list only Cache-Control/Pragma/Expires/
+     * X-Content-Type-Options/HSTS/X-Frame-Options/X-XSS-Protection as
+     * defaults. {@code strict-origin-when-cross-origin} avoids leaking the
+     * full referrer URL cross-origin while still allowing same-origin
+     * analytics.
+     */
+    public static final String REFERRER_POLICY =
+            "strict-origin-when-cross-origin";
+
+    /**
+     * Permissions-Policy is not added by Spring Security at all (confirmed
+     * via the same 6.5 docs — "Spring Security does not add
+     * Permissions-Policy headers by default"). BuildNest uses none of
+     * these browser features server-side or in the SPA, so every
+     * directive is denied outright rather than scoped to 'self'.
+     */
+    public static final String PERMISSIONS_POLICY =
+            "geolocation=(), camera=(), microphone=(), payment=(), usb=()";
 
     private SecurityHeaderPolicies() {
     }

--- a/backend/src/test/java/com/example/buildnest_ecommerce/config/TestSecurityConfig.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/config/TestSecurityConfig.java
@@ -130,7 +130,13 @@ public class TestSecurityConfig {
                         .httpStrictTransportSecurity(hsts -> hsts
                                 .includeSubDomains(true)
                                 .preload(true)
-                                .maxAgeInSeconds(SecurityHeaderPolicies.HSTS_MAX_AGE_SECONDS)))
+                                .maxAgeInSeconds(SecurityHeaderPolicies.HSTS_MAX_AGE_SECONDS))
+                        .referrerPolicy(referrer -> referrer
+                                .policy(org.springframework.security.web.header.writers
+                                        .ReferrerPolicyHeaderWriter.ReferrerPolicy
+                                        .STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                        .permissionsPolicy(permissions -> permissions
+                                .policy(SecurityHeaderPolicies.PERMISSIONS_POLICY)))
                 .cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration corsConfig = new CorsConfiguration();
                     // #630: setAllowedOrigins("*") + allowCredentials(true) throws

--- a/backend/src/test/java/com/example/buildnest_ecommerce/security/SecurityHeadersTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/security/SecurityHeadersTest.java
@@ -56,4 +56,25 @@ class SecurityHeadersTest {
                 .andExpect(header().string("Strict-Transport-Security",
                         "max-age=" + SecurityHeaderPolicies.HSTS_MAX_AGE_SECONDS + " ; includeSubDomains ; preload"));
     }
+
+    @Test
+    @DisplayName("main-chain response includes X-Content-Type-Options: nosniff (SEC-11/SEC-12, #112)")
+    void mainChainIncludesContentTypeOptionsNosniff() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"));
+    }
+
+    @Test
+    @DisplayName("main-chain response includes Referrer-Policy matching the shared policy constant (SEC-11/SEC-12, #112)")
+    void mainChainIncludesReferrerPolicy() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(header().string("Referrer-Policy", SecurityHeaderPolicies.REFERRER_POLICY));
+    }
+
+    @Test
+    @DisplayName("main-chain response includes Permissions-Policy matching the shared policy constant (SEC-11/SEC-12, #112)")
+    void mainChainIncludesPermissionsPolicy() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(header().string("Permissions-Policy", SecurityHeaderPolicies.PERMISSIONS_POLICY));
+    }
 }

--- a/docs/SDLC-docs/requirement-engineering/requirements-traceability-matrix.md
+++ b/docs/SDLC-docs/requirement-engineering/requirements-traceability-matrix.md
@@ -10,12 +10,12 @@
 | :--- | :--- |
 | **Document Title** | Requirements Traceability Matrix (RTM) |
 | **Document ID** | RTM-BUILDNEST-001 |
-| **Version** | 1.44 |
-| **Date** | 2026-07-30 IST |
+| **Version** | 1.45 |
+| **Date** | 2026-08-01 IST |
 | **Status** | Controlled — Under Review |
 | **Classification** | Internal Use |
 | **Conformance Standard** | ISO/IEC/IEEE 29148:2018 §6.2.5 (Traceability) |
-| **Related SRS** | SRS-BUILDNEST-001 v5.8 — `docs/SDLC-docs/requirement-engineering/software-requirements-specification.md` |
+| **Related SRS** | SRS-BUILDNEST-001 v5.9 — `docs/SDLC-docs/requirement-engineering/software-requirements-specification.md` |
 | **Related SDD** | SDD-BUILDNEST-001 v4.13 — `docs/SDLC-docs/design/software-design-description.md` |
 | **Related TP** | TP-BUILDNEST-001 v4.5 — `docs/SDLC-docs/software-testing/test-plan.md` |
 | **Baseline Assessment** | `docs/reports/baseline-assessment-2026-06-19.md` |
@@ -73,6 +73,7 @@
 | 1.42 | 2026-07-29 IST | QA Manager | Added SEC-15 (#111): full OWASP Top 10 (2021) assessment (A01-A10), performed against the local dev stack (no staging environment exists yet — `development-workflow.md` step 31, confirmed via user decision) using OWASP ZAP full active scan (141 automated checks, 0 Fail/Warn, 1 Informational) plus direct code/live-endpoint review. One Medium finding (A10 SSRF: `WebhookServiceImpl`'s admin-supplied `targetUrl` had no private-IP/loopback blocklist) fixed in the same PR via a new `SsrfUrlValidator` component, with dedicated unit tests. Zero Critical/High findings — see `docs/SDLC-docs/reports/security-assessment.md` for the full per-category writeup. Corrected a filing-time traceability mismatch: issue #111 was titled "(SEC-02)", but SEC-02 is an unrelated, already-Implemented requirement (JWT secret length) — SEC-15 is the correct, newly-added FR this issue satisfies. Recomputed the Security Coverage Summary row (14→15 total, 10→11 Implemented) and the Coverage Summary Totals row (183→184 total, 123→124 Implemented) | Pending |
 | 1.43 | 2026-07-30 IST | QA Manager | Periodic 15-issue SDLC documentation sync (overdue — last performed at #452, 2026-07-17; 53 issues closed since, well past the 15-issue trigger). Recomputed the Seller & Marketplace (FR-SEL) Coverage Summary row directly from its 8 individual rows (376-383): all 8 are ✅ Implemented, correcting the stale "5 Implemented / 3 Not Started (Ph-3, Planned)" that no single issue's own scope had covered recomputing. Folded FR-SEL (8/8) and FR-LOC (4/4) into the Totals row per this document's own previously-stated fold-in criterion (implementation begun, OQ-01/OQ-02 resolved) — Totals 184→196 total, 124→136 Implemented. Cross-reference mesh sweep: corrected `Related SRS` (5.6→5.8, since SRS's own version is also bumped in this same sync pass) and `Related TP` (4.3→4.5, same reason); `Related SDD` was already current (4.12) before this pass, bumped to 4.13 alongside SDD's own sync edit | Pending |
 | 1.44 | 2026-07-30 IST | QA Manager | FR-PAY-05 (Razorpay credentials externalised via env vars) corrected from 🔵 Pending Ph-2 to ✅ Implemented: `application.properties`' `razorpay.key.secret`/`razorpay.webhook.secret` previously carried literal string defaults (`test_key_secret`/`test_webhook_secret`) that applied in production too, since `application-production.properties` never overrode them — a hardcoded-secret-with-default violation, not genuine env-var externalisation (#114, secrets audit against SDP Appendix B / RGAR §11). Removed both defaults so a missing env var now fails startup instead of silently falling back to a known secret; also removed two redundant weak Java-level `@Value` defaults (`JwtTokenProvider.jwtSecret`, `ElasticsearchConfig.password`) masked by properties-level indirection. Added a `gitleaks` CI step (`security.yml`) and `.gitleaks.toml` allowlisting confirmed documentation/test-fixture false positives; fixed a real finding in `backend/kubernetes/buildnest-deployment.yaml` (a Secret manifest with real-looking base64 "example" values, now `stringData` placeholders). Recomputed the Payment (FR-PAY) Coverage Summary row (0→1 Implemented, 2→1 Pending) and the Coverage Summary Totals row (136→137 Implemented, 45→44 Pending) | Pending |
+| 1.45 | 2026-08-01 IST | QA Manager | Added SEC-16 (HTTP security headers: HSTS/X-Frame-Options/X-Content-Type-Options/Referrer-Policy/Permissions-Policy, #112) — correcting the issue's own stale "SRS SEC-11, SEC-12" citation (unrelated: search rate limiting, JWT rotation). HSTS/X-Frame-Options/X-Content-Type-Options were already Spring Security defaults (verified via context7 against the 6.5 reference docs); Referrer-Policy and Permissions-Policy were genuinely missing, added to `SecurityHeaderPolicies`/`SecurityConfig`/`TestSecurityConfig`, and covered by 3 new `SecurityHeadersTest` assertions (5/5 pass). Recomputed the Security (SEC) Coverage Summary row (15→16 total, 11→12 Implemented) and the Coverage Summary Totals row (196→197 total, 137→138 Implemented). Updated `Related SRS` from v5.8 to v5.9 | Pending |
 
 ### Document Approval
 
@@ -141,7 +142,7 @@ The RTM serves to:
 | Performance (PR) | 8 | 3 | 0 | 5 | 0 | 0 |
 | Reliability (REL) | 5 | 2 | 0 | 3 | 0 | 0 |
 | Availability (AVL) | 4 | 1 | 0 | 3 | 0 | 0 |
-| Security (SEC) | 15 | 11 | 1 | 3 | 0 | 0 |
+| Security (SEC) | 16 | 12 | 1 | 3 | 0 | 0 |
 | Maintainability (MNT) | 6 | 6 | 0 | 0 | 0 | 0 |
 | Portability (PRT) | 4 | 1 | 0 | 3 | 0 | 0 |
 | Scalability (SCL) | 4 | 2 | 0 | 2 | 0 | 0 |
@@ -150,7 +151,7 @@ The RTM serves to:
 | Test Integrity (TIR) | 5 | 4 | 1 | 0 | 0 | 0 |
 | Seller & Marketplace (FR-SEL) | 8 | 8 | 0 | 0 | 0 | 0 |
 | Location-Based Matching (FR-LOC) | 4 | 4 | 0 | 0 | 0 | 0 |
-| **Totals** | **196** | **137** | **15** | **44** | **0** | **0** |
+| **Totals** | **197** | **138** | **15** | **44** | **0** | **0** |
 
 > **Phase 1 gate posture**: 93 requirements fully implemented, 0 open defects. TIR-01 through TIR-04 and MNT-03 (previously blocking Phase 1 exit) were verified fixed on 2026-07-17 (#452) — `ProductApiTest`/`OrderApiTest` are `@Tag("e2e")`, `AuthServiceImplTest` mocks `RoleRepository`, both security-test assertions match their actual (correct) HTTP status codes, and MNT-02/TIR-05's coverage-gate values were corrected to their real, higher configured thresholds (85% JaCoCo, 77% PIT). Phase 1 is no longer blocked by test-integrity defects. (Totals recomputed directly from the 24 category rows above — the previous release's Totals row did not actually sum to its own category rows, independent of this fix.)
 >
@@ -463,6 +464,7 @@ The RTM serves to:
 | SEC-13 | Database password rotation every 180 days | Medium | Ph-2 | Appendix A | HikariCP env var `${SPRING_DATASOURCE_PASSWORD}` | Operational runbook | Inspection | 🔵 Pending Ph-2 |
 | SEC-14 | CSP must not contain `unsafe-inline` | Medium | Ph-2 | §5.1.4 | `SecurityConfig`/`SecurityHeaderPolicies.MAIN_CSP` (backend API, #237); `frontend/security-headers.conf` (frontend document CSP, #110 — removed `unsafe-inline` from `style-src`; React's `style={{}}` prop sets styles via JS property assignment, not the HTML `style` attribute, so it is not subject to the `style-src` inline restriction) | `SecurityTest`, live-browser CSP verification (#110) | Inspection + Test | ✅ Implemented |
 | SEC-15 | Full OWASP Top 10 (2021) assessment (A01–A10) performed and documented before M5 gate; zero open Critical, High findings have a remediation timeline | High | Ph-2 | §5.1 (new) | `docs/SDLC-docs/reports/security-assessment.md`; `WebhookServiceImpl`/`SsrfUrlValidator` (A10 SSRF remediation) | `SsrfUrlValidatorTest`, `WebhookServiceImplTest`, OWASP ZAP full active scan (local, #111) | Inspection + Test | ✅ Implemented |
+| SEC-16 | HSTS (max-age ≥31536000, includeSubDomains), X-Frame-Options: DENY, X-Content-Type-Options: nosniff, Referrer-Policy, Permissions-Policy on all API responses | High | Ph-2 | §5.1 (new) | `SecurityConfig`/`SecurityHeaderPolicies` (`REFERRER_POLICY`, `PERMISSIONS_POLICY` — #112; HSTS/X-Frame-Options/X-Content-Type-Options already Spring Security defaults) | `SecurityHeadersTest` (5/5) | Inspection + Test | ✅ Implemented |
 
 ### 7.6 Maintainability Requirements
 

--- a/docs/SDLC-docs/requirement-engineering/software-requirements-specification.md
+++ b/docs/SDLC-docs/requirement-engineering/software-requirements-specification.md
@@ -10,8 +10,8 @@
 | :--- | :--- |
 | **Document Title** | Software Requirements Specification (SRS) |
 | **Document ID** | SRS-BUILDNEST-001 |
-| **Version** | 5.8 |
-| **Date** | 2026-07-30 IST |
+| **Version** | 5.9 |
+| **Date** | 2026-08-01 IST |
 | **Status** | Controlled — Under Review |
 | **Classification** | Internal Use |
 | **Conformance Standard** | ISO/IEC/IEEE 29148:2018 |
@@ -47,6 +47,7 @@
 | 5.6 | 2026-07-29 IST | Technical Lead | SEC-14 (#110): backend CSP was already `unsafe-inline`-free since #237, but the frontend's own document CSP (`frontend/security-headers.conf`) still carried `unsafe-inline` on `style-src`; removed after confirming React's `style={{}}` prop doesn't trigger the inline-style CSP restriction (JS property assignment, not the `style=` HTML attribute). Updated the SEC-14 Note in §7 (or equivalent security-requirements section) from "known gap for Ph-1" to resolved | Pending |
 | 5.7 | 2026-07-29 IST | Technical Lead | Added SEC-15 (#111): OWASP Top 10 2021 assessment requirement, correcting a filing-time traceability mismatch where the issue cited "(SEC-02)" (an unrelated, already-satisfied JWT-length requirement) and a blanket "SEC-01 to SEC-15" range that didn't exist yet. Updated SN-06 and the Coverage Summary Security row from SEC-01–14 to SEC-01–15 (14→15 requirements, 9→10 High). See `docs/SDLC-docs/reports/security-assessment.md` for the full A01–A10 assessment | Pending |
 | 5.8 | 2026-07-30 IST | Technical Lead | Periodic 15-issue SDLC documentation sync (overdue — last performed at #452, 2026-07-17; 53 issues closed since). Corrected a stale Spring Boot version claim (3.5.10 → 3.5.16, verified directly against `backend/pom.xml`'s `spring-boot-starter-parent`) in 3 places (REF-08, §4.2's Backend Framework row, CON-02) — this had drifted through several patch releases with no single issue's own scope covering a re-verification. MySQL 8.2 / Redis 7 / Elasticsearch 8.17 claims re-checked against `docker-compose.yml`'s active (non-commented) service definitions — still accurate, no change needed | Pending |
+| 5.9 | 2026-08-01 IST | Technical Lead | Added SEC-16 (#112): HTTP security headers (HSTS/X-Frame-Options/X-Content-Type-Options/Referrer-Policy/Permissions-Policy), correcting a filing-time traceability mismatch where the issue cited "SRS SEC-11, SEC-12" (unrelated: search rate limiting, JWT rotation). Verified against the Spring Security 6.5 reference docs (context7) that HSTS/X-Frame-Options/X-Content-Type-Options are already framework defaults; Referrer-Policy and Permissions-Policy were genuinely missing and implemented. Updated the Coverage Summary Security row from SEC-01–15 to SEC-01–16 (15→16 requirements, 10→11 High) | Pending |
 
 ### Document Change Procedure
 
@@ -417,7 +418,7 @@ Per ISO/IEC/IEEE 29148:2018 Clause 6.3:
 | SN-03 | Administrators | Real-time visibility into sales, inventory, and user activity | FG-06, FG-08, FG-09 |
 | SN-04 | Business Owners | Scalable platform supporting growth to 1,000+ concurrent users | PR-02, SCL-01–04 |
 | SN-05 | DevOps / SRE | Observable, container-ready application with zero-downtime deployments | FG-09, PRT-01–04 |
-| SN-06 | Security Auditors | Compliance with OWASP, PCI-DSS, and GDPR standards | SEC-01–15 |
+| SN-06 | Security Auditors | Compliance with OWASP, PCI-DSS, and GDPR standards | SEC-01–16 |
 | SN-07 | QA Engineers | A test suite whose pass signal is trustworthy and reflects real system behaviour | TIR-01–05 |
 | SN-08 | Sellers *(Ph-3, Planned)* | A way to reach buyers beyond their existing offline shop's foot traffic, within a service area they can realistically fulfil | FG-11, FG-12 |
 
@@ -839,6 +840,9 @@ All of the following indexes shall be present in the production schema:
 | SEC-13 | Database password rotation shall be performed every 180 days following documented procedures | Ph-2 | Medium | Inspection |
 | SEC-14 | The Content-Security-Policy response header shall not include `unsafe-inline`; inline script execution shall be prevented via nonce or hash strategy | Ph-2 | Medium | Inspection |
 | SEC-15 | A full OWASP Top 10 (2021) assessment (A01–A10) shall be performed and documented before the M5 production-readiness gate, with zero open Critical findings and a remediation timeline for any open High findings | Ph-2 | High | Test |
+| SEC-16 | API responses shall include HSTS (`max-age` ≥31536000, `includeSubDomains`), `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, and `Permissions-Policy` headers | Ph-2 | High | Test |
+
+> **Note on SEC-16** (#112): no prior SRS row covered this header bundle — the issue's own References cited SEC-11/SEC-12 (search rate limiting, JWT rotation), a stale/incorrect citation unrelated to HTTP headers. HSTS/X-Frame-Options/X-Content-Type-Options were already correctly enforced by Spring Security defaults; Referrer-Policy and Permissions-Policy were genuinely missing and added.
 
 > **Note on SEC-14**: Resolved. Backend `SecurityConfig`/`SecurityHeaderPolicies.MAIN_CSP` removed `unsafe-inline` from the API CSP in #237 (SEC-14); the frontend's own document CSP (`frontend/security-headers.conf`) retained `unsafe-inline` on `style-src` until #110, which removed it after confirming (live-browser verification) that React's `style={{}}` prop does not trigger the `style-src` inline restriction, since it sets styles via JS property assignment rather than the HTML `style` attribute.
 
@@ -953,7 +957,7 @@ Test integrity requirements define the properties that the test suite itself mus
 | Performance (PR-01–08) | 8 | Ph-1 / Ph-2 | 4 High, 3 Medium, 1 Low | Analysis, Inspection |
 | Reliability (REL-01–05) | 5 | Ph-1 / Ph-2 | Mixed | Analysis, Inspection |
 | Availability (AVL-01–04) | 4 | Ph-2 | High | Test |
-| Security (SEC-01–15) | 15 | Ph-1 / Ph-2 | 10 High, 5 Medium | Inspection, Test |
+| Security (SEC-01–16) | 16 | Ph-1 / Ph-2 | 11 High, 5 Medium | Inspection, Test |
 | Maintainability (MNT-01–06) | 6 | Ph-1 / Ph-2 | Mixed | Build, Inspection |
 | Portability (PRT-01–04) | 4 | Ph-1 / Ph-2 | Mixed | Inspection |
 | Scalability (SCL-01–04) | 4 | Ph-1 / Ph-2 | Mixed | Analysis, Inspection |

--- a/docs/SDLC-docs/software-testing/test-plan.md
+++ b/docs/SDLC-docs/software-testing/test-plan.md
@@ -10,8 +10,8 @@
 | :--- | :--- |
 | **Document Title** | Test Plan |
 | **Document ID** | TP-BUILDNEST-001 |
-| **Version** | 4.6 |
-| **Date** | 2026-07-30 IST |
+| **Version** | 4.7 |
+| **Date** | 2026-08-01 IST |
 | **Status** | Controlled — Under Review |
 | **Classification** | Internal Use |
 | **Conformance Standard** | ISO/IEC/IEEE 29119-3:2021 |
@@ -37,6 +37,7 @@
 | 4.4 | 2026-07-29 IST | Test Manager | SEC-14 (#110): §13.2's "Remove CSP `unsafe-inline`; update `SecurityTest` assertions" task struck through as done (#237 backend, #110 frontend). `Related SRS`/`Related SDD` header fields were long-stale (v4.5/v3.4, real current v5.6/v4.12 — several intervening version bumps on both documents never propagated here); corrected while already touching this document's content, though a full cross-reference-mesh sweep is the periodic 15-issue sync's job, not a per-issue one | Pending |
 | 4.5 | 2026-07-30 IST | Test Manager | Periodic 15-issue SDLC documentation sync (overdue — last full sync at #452/#461, 2026-07-17; 53 issues closed since). §17.2's frontend-coverage baseline (17 test files/121 tests) corrected to the real current state via a fresh `npx vitest run`: 45 test files, 281 tests, all passing — the frontend grew substantially (Ph-3 marketplace-pivot seller/district UI, plus several M4 feature issues) with no single issue's own scope covering a re-verification of this aggregate row. Backend baseline (§17.2's own table) also drifted: re-ran a clean `./mvnw test` in an `env -i` isolated shell — 195→216 test files, 1,735→1,893 test executions, 0 failures/0 errors (matches PR #622's own test-plan citation for #111). §17.1's JaCoCo (85%)/PIT (77%) gate values re-checked directly against `pom.xml` — still accurate, no change. `Related SRS`/`Related SDD` updated (5.6→5.8, 4.12→4.13) | Pending |
 | 4.6 | 2026-07-30 IST | Test Manager | Added a "Secret hardcoding" row to §5.2 Security Testing (FR-PAY-05, SDP Appendix B) for #114's hardcoded-secrets audit — no `@Value` secret defaults, `gitleaks` CI step on every push/PR, verified via `RazorpayClientAdapterTest` plus empirical CI-run verification (the CI step itself has no unit-test equivalent) | Pending |
+| 4.7 | 2026-08-01 IST | Test Manager | Added SEC-16 (#112) to the "Security Headers" rows (§4/§5.2): Referrer-Policy and Permissions-Policy, previously untested since they didn't exist in the config, now covered by 3 new `SecurityHeadersTest` assertions (5/5 pass) alongside the pre-existing HSTS/X-Frame-Options coverage. Updated the §17-equivalent Security requirement-coverage row from SEC-01–14 to SEC-01–16 | Pending |
 
 ### Document Approval
 
@@ -182,7 +183,7 @@ This document covers testing of:
 | Webhook Management | Register, Trigger, Event delivery | FR-ADM-07 | Ph-1 |
 | Notifications | Event-driven email/notification dispatch | FR-NOT-01 to FR-NOT-03 | Ph-1 |
 | Monitoring & Health | `/actuator/health`, `/actuator/prometheus`, performance metrics | FR-MON-01 to FR-MON-08 | Ph-1 |
-| Security Headers | HSTS, X-Frame-Options, X-Content-Type-Options, CSP | SEC-03, SEC-05, SEC-14 | Ph-1 |
+| Security Headers | HSTS, X-Frame-Options, X-Content-Type-Options, CSP, Referrer-Policy, Permissions-Policy | SEC-03, SEC-05, SEC-14, SEC-16 | Ph-1 |
 | Resilience Patterns | Circuit breaker, time limiter, graceful degradation | REL-02, REL-03, AVL-04 | Ph-1 |
 | Input Validation & Sanitisation | Injection prevention, field constraints, HTTP 400 on invalid input | SEC-06, SEC-06 | Ph-1 |
 | Frontend Components | React components, routing, auth flow, cart, checkout | FR-FE-01 to FR-FE-30 | Ph-2 |
@@ -474,7 +475,7 @@ Verifies that the system meets SRS v4.0 Security Requirements (SEC-*) and OWASP 
 | Authorisation | RBAC enforcement; 401 vs 403 distinction | SEC-01, FR-AUTH-10 | `AuthenticationAuthorizationSecurityTest`, `RBACTest` |
 | Rate limiting | Login lockout; admin throttle; fail-open on Redis down | SEC-07 to SEC-11 | `AdminRateLimitFilterTest`, `RateLimiterServiceTest` |
 | Input validation | SQL injection, XSS, null byte, oversized payload rejection | SEC-06 | `InputValidationSecurityTest`, `InputValidationTest` |
-| HTTP security headers | HSTS, X-Frame-Options, X-Content-Type-Options, CSP | SEC-03, SEC-05, SEC-14 | `SecurityTest`, `AuthenticationAuthorizationSecurityTest` |
+| HTTP security headers | HSTS, X-Frame-Options, X-Content-Type-Options, CSP, Referrer-Policy, Permissions-Policy | SEC-03, SEC-05, SEC-14, SEC-16 | `SecurityTest`, `AuthenticationAuthorizationSecurityTest`, `SecurityHeadersTest` |
 | JWT key strength | Reject keys shorter than 512 bits at startup | SEC-02, FR-AUTH-05 | `JwtKeyValidatorTest` |
 | Sensitive data exposure | Passwords not in logs or responses; PII masked | SEC-04 | `SecureLoggerTest`, `UserTest` |
 | BCrypt hashing | Password stored as BCrypt hash; rounds ≥ 12 | SEC-02 | `AuthServiceImplTest` |
@@ -901,7 +902,7 @@ The table below maps SRS v4.0 requirement groups to the test classes that verify
 | Webhooks | FR-ADM-07 | `WebhookAdminControllerTest`, `WebhookServiceImplTest` |
 | Notifications | FR-NOT-01 to FR-NOT-03 | `NotificationServiceTest`, `DomainEventListenerTest` |
 | Monitoring | FR-MON-01 to FR-MON-08 | `HealthIndicatorTest`, `DatabaseHealthIndicatorTest`, `RedisHealthIndicatorTest`, `PerformanceMetricsControllerTest`, `PoolMetricsControllerTest` |
-| Security | SEC-01 to SEC-14 | `AuthenticationAuthorizationSecurityTest`, `InputValidationSecurityTest`, `SecurityTest`, `AdminRateLimitFilterTest`, `RateLimiterServiceTest`, `JwtKeyValidatorTest`, `CustomUserDetailsTest`, `RolePermissionEvaluatorTest` |
+| Security | SEC-01 to SEC-16 | `AuthenticationAuthorizationSecurityTest`, `InputValidationSecurityTest`, `SecurityTest`, `AdminRateLimitFilterTest`, `RateLimiterServiceTest`, `JwtKeyValidatorTest`, `CustomUserDetailsTest`, `RolePermissionEvaluatorTest`, `SecurityHeadersTest` |
 | Performance | PR-01 to PR-07 | `PerformanceTest`, `PerformanceBaselineTest`, `LoadTestSimulation` (Gatling) |
 | Reliability | REL-01 to REL-04, AVL-01 to AVL-04 | `ReliabilityTest`, `ReliabilityHATest` |
 | Auditability | MNT-05 | `AuditAspectTest`, `AuditLogServiceTest`, `AuditLogControllerTest` |


### PR DESCRIPTION
## Summary
- Closes #112. HSTS, X-Frame-Options, X-Content-Type-Options were already correctly enforced (Spring Security defaults, verified against the 6.5 reference docs via context7). Referrer-Policy and Permissions-Policy were genuinely missing — Spring Security does not add either by default.
- Added `SecurityHeaderPolicies.REFERRER_POLICY` (`strict-origin-when-cross-origin`) and `PERMISSIONS_POLICY` (denies geolocation/camera/microphone/payment/usb — none used server-side or in the SPA), wired into both `SecurityConfig`'s main chain and `TestSecurityConfig`'s test-profile stand-in via the existing shared-constants pattern from #312, so the two configs can't drift apart.
- **Traceability correction**: the issue's own References cited "SRS SEC-11, SEC-12" — both unrelated (search rate limiting, JWT rotation, respectively). Added SEC-16 as the correct, dedicated SRS/RTM requirement, following the same correction pattern already applied to #111/SEC-15.

## Test plan
- [x] `SecurityHeadersTest` extended with 3 new assertions (X-Content-Type-Options: nosniff, Referrer-Policy, Permissions-Policy) — 5/5 pass
- [x] SDLC docs updated: SRS (SEC-16 added, v5.8→5.9), RTM (v1.44→1.45), test-plan.md (v4.6→4.7), CHANGELOG
- [x] Mandatory security checklist run — no secrets, no new attack surface, existing CSRF/authn/authz/rate-limiting untouched