### PR TITLE
chore: wire Vitest and ESLint into CI — frontend unit/lint checks never run (#649)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,65 @@ jobs:
               body
             });
 
+  # #649: frontend unit/lint checks had zero CI enforcement (npm run test / npm run lint
+  # were never invoked anywhere in CI — only npm ci/build/preview inside the E2E jobs to
+  # produce a servable build). Deliberately NOT added to branch protection's
+  # required_status_checks yet (this repo currently has 6 required contexts, none
+  # frontend-related) — starts non-blocking so the job can prove itself green across a
+  # few real runs before being promoted to required, avoiding blocking merges on a
+  # brand-new job's first runs. Gated at step level (never job-level) per #412/#414's
+  # required-check-in-paths-ignore lesson, so this job's own status always reports even
+  # on a docs-only change, in case it's promoted to required later.
+  frontend-quality:
+    name: Frontend Lint & Test
+    runs-on: ubuntu-latest
+    needs: detect-changes
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        if: needs.detect-changes.outputs.code-changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        if: needs.detect-changes.outputs.code-changed == 'true'
+        working-directory: frontend
+        run: npm ci --legacy-peer-deps
+
+      - name: Run ESLint
+        if: needs.detect-changes.outputs.code-changed == 'true'
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Run Vitest with coverage
+        if: needs.detect-changes.outputs.code-changed == 'true'
+        working-directory: frontend
+        run: npm run test:coverage
+
+      - name: Upload frontend coverage to Codecov
+        if: needs.detect-changes.outputs.code-changed == 'true'
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./frontend/coverage
+          flags: frontend
+          name: codecov-frontend
+          fail_ci_if_error: false
+          verbose: true
+
+      - name: Upload frontend coverage artifact
+        if: needs.detect-changes.outputs.code-changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          retention-days: 30
+
   quality-gates:
     name: Quality Gates
     runs-on: ubuntu-latest
@@ -379,7 +438,7 @@ jobs:
   notify:
     name: Notify Results
     runs-on: ubuntu-latest
-    needs: [build, quality-gates, dependency-check]
+    needs: [build, quality-gates, dependency-check, frontend-quality]
     if: always()
 
     steps:
@@ -389,6 +448,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Build Status**: ${{ needs.build.result }}" >> $GITHUB_STEP_SUMMARY
           echo "**Quality Gates**: ${{ needs.quality-gates.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Frontend Lint & Test**: ${{ needs.frontend-quality.result }}" >> $GITHUB_STEP_SUMMARY
           echo "**OWASP Dependency-Check**: ${{ needs.dependency-check.result }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Artifacts Available**:" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
   job's own non-required status, so both can prove themselves stable before
   being tightened). Not yet added to branch protection's
   `required_status_checks` (6 existing required contexts, none frontend-
-  related) — deliberately starts non-blocking; promoting it is a follow-up
+  related) — deliberately starts non-blocking; filed #657 to promote it
   once a few green runs are observed. Fixed two pre-existing gaps this
   surfaced: `eslint.config.js`'s `globalIgnores` didn't exclude the
   generated `coverage/` directory, and `AuthContext.tsx` had a real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
 ## [Unreleased] — M4: Feature Development
 
 ### Added
+- Wired frontend unit tests and lint into CI (#649, M5): new `frontend-quality`
+  job in `.github/workflows/ci.yml` runs `npm run lint` and
+  `npm run test:coverage` on every PR/push, gated at step level (per #412/
+  #414's required-check-in-`paths-ignore` lesson) so its status always
+  reports even on docs-only changes. Vitest coverage-v8 output uploads to
+  Codecov under a new `frontend` flag (no threshold gate yet — decision
+  recorded via `AskUserQuestion`: start ungated/non-blocking, matching the
+  job's own non-required status, so both can prove themselves stable before
+  being tightened). Not yet added to branch protection's
+  `required_status_checks` (6 existing required contexts, none frontend-
+  related) — deliberately starts non-blocking; promoting it is a follow-up
+  once a few green runs are observed. Fixed two pre-existing gaps this
+  surfaced: `eslint.config.js`'s `globalIgnores` didn't exclude the
+  generated `coverage/` directory, and `AuthContext.tsx` had a real
+  `react-refresh/only-export-components` violation (a context file
+  exporting both its provider and consumer hook, a legitimate pattern —
+  disabled the rule for that one line with a comment explaining why).
+  Filed #655 for a flaky `ProductsTab.test.tsx` timeout discovered while
+  verifying the new job (intermittent under full-suite load, not
+  reproducible in isolation — separate concern, not blocking this issue).
 - Playwright E2E test suite (#117, M5): `frontend/e2e/` covers the full
   user journey (register → browse → search → add-to-cart → checkout →
   order confirmation → order history) plus two critical error paths

--- a/docs/SDLC-docs/software-testing/test-plan.md
+++ b/docs/SDLC-docs/software-testing/test-plan.md
@@ -288,8 +288,8 @@ git push → CI triggered
       Coverage uploaded to Codecov under a `frontend` flag — not yet gated on a
       threshold (deliberate, non-blocking start; see CHANGELOG #649)
       Gate: 0 lint errors, 0 test failures — NOT yet a required branch-protection
-      check (started non-blocking; promoting it to required is a tracked follow-up
-      once observed stable across several runs)
+      check (started non-blocking; #657 tracks promoting it to required once
+      observed stable across several runs)
 ```
 
 ---

--- a/docs/SDLC-docs/software-testing/test-plan.md
+++ b/docs/SDLC-docs/software-testing/test-plan.md
@@ -10,7 +10,7 @@
 | :--- | :--- |
 | **Document Title** | Test Plan |
 | **Document ID** | TP-BUILDNEST-001 |
-| **Version** | 4.9 |
+| **Version** | 4.10 |
 | **Date** | 2026-08-02 IST |
 | **Status** | Controlled — Under Review |
 | **Classification** | Internal Use |
@@ -40,6 +40,7 @@
 | 4.7 | 2026-08-01 IST | Test Manager | Added SEC-16 (#112) to the "Security Headers" rows (§4/§5.2): Referrer-Policy and Permissions-Policy, previously untested since they didn't exist in the config, now covered by 3 new `SecurityHeadersTest` assertions (5/5 pass) alongside the pre-existing HSTS/X-Frame-Options coverage. Updated the §17-equivalent Security requirement-coverage row from SEC-01–14 to SEC-01–16 | Pending |
 | 4.8 | 2026-08-01 IST | Test Manager | §9.1 entry criteria row corrected: Playwright is now installed and configured (`frontend/e2e/`, `npm run test:e2e`, #117), no longer "still pending". §4.5 E2E section unchanged in structure — Playwright coexists with the pre-existing Selenium suite pending its retirement (#647) | Pending |
 | 4.9 | 2026-08-02 IST | Test Manager | #647: retired only the browser-driven Selenium E2E class (`E2ETest.java`) now that `playwright-e2e` demonstrated 3/3 real green runs on `master`. Mid-implementation correction: an initial pass wrongly deleted the entire `e2e/` package — including the separate, still-valid RestAssured API E2E suite (`BaseApiTest`, `AuthApiTest`/`CartApiTest`/`OrderApiTest`/`ProductApiTest`/`UserApiTest`) and `E2ESeedDataRunnerTest.java` (unit test for the Playwright job's own seed runner) — based on a false assumption that the whole directory was the Selenium suite; caught before commit, files restored, and the `e2e-tests` Maven profile/`e2e,` exclusion (needed by the RestAssured suite) restored in `pom.xml`. §4.5 rewritten to document both E2E suites separately (4.5.1 Playwright, 4.5.2 RestAssured) rather than treating them as one. TIR-01 (§15), §3.2 pipeline diagram, §8.2 Maven profile table, and Appendix C's pom.xml excerpt all corrected to reflect that the `e2e`/`@Tag("e2e")` mechanism still exists for the RestAssured suite | Pending |
+| 4.10 | 2026-08-02 IST | Test Manager | #649: §3.4's CI Pipeline Integration diagram never mentioned frontend lint/unit tests — `npm run test`/`npm run lint` had zero CI enforcement until this issue wired them into a new `frontend-quality` job (`ci.yml`). Added Stage 6 to the diagram documenting the new job, its Codecov `frontend` flag (uploaded, not yet threshold-gated), and its deliberately non-required branch-protection status | Pending |
 
 ### Document Approval
 
@@ -276,11 +277,19 @@ git push → CI triggered
 │     PIT gate: mutation score ≥ 75%
 │     Gate: both thresholds met
 │
-└── Stage 5: E2E Tests
-      Browser (Playwright, playwright-e2e CI job): npm run test:e2e (frontend/) — real
-      backend (H2, e2e.seed.enabled=true) + vite preview frontend, both self-started
-      API (RestAssured, e2e-tests CI job, runs in parallel): ./mvnw test -P e2e-tests
-      Gate: 0 failures (both jobs)
+├── Stage 5: E2E Tests
+│     Browser (Playwright, playwright-e2e CI job): npm run test:e2e (frontend/) — real
+│     backend (H2, e2e.seed.enabled=true) + vite preview frontend, both self-started
+│     API (RestAssured, e2e-tests CI job, runs in parallel): ./mvnw test -P e2e-tests
+│     Gate: 0 failures (both jobs)
+│
+└── Stage 6: Frontend Lint + Unit Tests (frontend-quality CI job, ci.yml, #649)
+      npm run lint (ESLint) + npm run test:coverage (Vitest, coverage-v8)
+      Coverage uploaded to Codecov under a `frontend` flag — not yet gated on a
+      threshold (deliberate, non-blocking start; see CHANGELOG #649)
+      Gate: 0 lint errors, 0 test failures — NOT yet a required branch-protection
+      check (started non-blocking; promoting it to required is a tracked follow-up
+      once observed stable across several runs)
 ```
 
 ---

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -15,7 +15,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -109,6 +109,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// Context files conventionally export both the provider and its consumer hook together.
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth(): AuthContextValue {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error('useAuth must be used inside AuthProvider');


### PR DESCRIPTION
## Summary
- Adds a new `frontend-quality` job to `.github/workflows/ci.yml` running `npm run lint` and `npm run test:coverage` on every PR/push against the frontend.
- Vitest coverage-v8 output uploads to Codecov under a new `frontend` flag — no threshold gate yet (decision recorded via `AskUserQuestion`: start ungated, matching the job's own non-required status).
- Deliberately **not** added to branch protection's `required_status_checks` yet (6 existing required contexts, none frontend-related) — starts non-blocking so it can prove itself green across a few real runs before being promoted to required. Tracked as a follow-up once observed stable.
- Fixed two pre-existing gaps this surfaced: `eslint.config.js`'s `globalIgnores` didn't exclude the generated `coverage/` dir (was linting its own coverage artifacts), and `AuthContext.tsx` had a real `react-refresh/only-export-components` violation (context files legitimately export both provider + consumer hook — disabled the rule for that one line with an explanatory comment).
- Filed #655 for a flaky `ProductsTab.test.tsx` timeout discovered while verifying the new job (intermittent under full-suite load only, not reproducible in isolation across 3 retries — pre-existing, unrelated to this change, tracked separately).

## Test plan
- [x] `npm run lint` — clean (0 errors, 0 warnings) after eslint.config.js/AuthContext.tsx fixes
- [x] `npm run test:coverage` — 281/281 tests pass, 87.65% statement coverage (confirmed via 3 full-suite runs; 1 unrelated flaky timeout traced to #655, not this change)
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Confirm the new `Frontend Lint & Test` job actually runs and reports real pass/fail on this PR (tier-0 empirical verification per testing.md — not just a green conclusion)

Closes #649