### PR TITLE
fix(resilience): degrade gracefully when Redis is down for @Cacheable (#650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,41 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
   to do with Selenium or browsers.
 
 ### Fixed
+- `@Cacheable` not gracefully degrading when Redis is down (#650,
+  discovered via #117's CI investigation): `RedisConnectionFailureException`
+  propagated through `ProductServiceImpl#getProductById` (and every other
+  `@Cacheable`/`@CacheEvict` call site — `CategoryServiceImpl`,
+  `AuditLogService`, `ProductTagServiceImpl`, `ProductServiceImpl`) all the
+  way to the controller, surfacing as a false 404 "product not found"
+  instead of falling through to the database — contradicting
+  `resilience4j.md`'s own stated "Redis (cache) — Fall through to
+  database — do not throw" fallback table, which only ever protected
+  manually circuit-breaker-wrapped Redis usage, not the declarative
+  `@Cacheable` proxy path. Fixed via a new `GracefulCacheErrorHandler`
+  (`config/GracefulCacheErrorHandler.java`), wired through
+  `CacheConfig implements CachingConfigurer#errorHandler()` — confirmed via
+  Spring source inspection that `@EnableCaching` does **not** auto-detect a
+  plain `CacheErrorHandler` bean by type, only one supplied via
+  `CachingConfigurer`. Only exceptions caused by a
+  `RedisConnectionFailureException` are swallowed (logged at `DEBUG`,
+  matching the resilience4j.md convention); any other cache exception,
+  e.g. a serialization failure indicating real data corruption (see #651),
+  is still rethrown. Covered by a real-proxy integration test
+  (`CacheRedisUnavailableIntegrationTest`, a genuine `@EnableCaching` AOP
+  context pointed at an unreachable Redis) plus a unit test for the
+  handler's own connection-vs-corruption branching
+  (`GracefulCacheErrorHandlerTest`).
+- `OWASP Dependency-Check` false-positive finding `CVE-2026-56816` (CVSS 7.5)
+  against `netty-transport-4.1.136.Final.jar` (#636, discovered via #630/PR
+  #634, unrelated to that branch's own diff): verified directly against the
+  NVD detail page — the vulnerability is in `Http3FrameCodec.decodeFrame`
+  (`io.netty.handler.codec.http3`), a 4.2.x-only HTTP/3/QUIC module. This
+  project is pinned to netty `4.1.136.Final` (#332) and has zero `http3`/
+  `quic` artifacts anywhere in its resolved dependency tree (`mvnw
+  dependency:tree` confirms this) — the vulnerable component is structurally
+  absent, not merely unpatched. Same false-positive shape as the existing
+  `CVE-2026-42582` suppression. Added a matching `owasp-suppressions.xml`
+  entry with full NVD-verification notes.
 - `ProductApiTest`'s `GET /api/v2/products` genuine `500` (#639, discovered
   via #635's own CSRF fix uncovering it): `Product.seller` (`@ManyToOne`,
   lazy) and `Product.tags` (`@ManyToMany`, lazy) were never included in any

--- a/backend/src/main/java/com/example/buildnest_ecommerce/config/CacheConfig.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/config/CacheConfig.java
@@ -1,14 +1,19 @@
 package com.example.buildnest_ecommerce.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer
+                .GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext
+                .SerializationPair;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 
@@ -18,7 +23,7 @@ import java.time.Duration;
  * Cache Configuration for application-level caching.
  * Implements distributed caching using Redis to improve performance (2.3
  * Performance Optimization).
- * 
+ *
  * LOW PRIORITY #14: Single Source of Truth for Cache TTLs
  * All cache TTL values are externalized to application.properties for
  * environment-specific configuration without code changes.
@@ -37,7 +42,7 @@ import java.time.Duration;
 @Configuration
 @EnableCaching
 @SuppressWarnings("null")
-public class CacheConfig {
+public class CacheConfig implements CachingConfigurer {
 
         // LOW PRIORITY #14: Cache TTL configuration values from properties
         // Single source of truth for all cache TTLs - externalized to
@@ -64,89 +69,97 @@ public class CacheConfig {
         private long relatedTtlMs;
 
         /**
-         * Configure Redis Cache Manager with custom TTL for different cache regions.
-         * LOW PRIORITY #14: Single source of truth for cache TTLs via externalized
-         * configuration.
-         * Improves performance by reducing database queries for frequently accessed
-         * data.
-         * 
+         * Falls through instead of throwing on a Redis connection
+         * failure (issue #650). Must come via {@link CachingConfigurer}
+         * — {@code @EnableCaching} does not auto-detect a plain
+         * {@link CacheErrorHandler} bean by type.
+         *
+         * @return the graceful cache error handler
+         */
+        @Override
+        public CacheErrorHandler errorHandler() {
+                return new GracefulCacheErrorHandler();
+        }
+
+        /**
+         * Configure Redis Cache Manager with custom TTL for different
+         * cache regions.
+         * LOW PRIORITY #14: Single source of truth for cache TTLs via
+         * externalized configuration.
+         * Improves performance by reducing database queries for
+         * frequently accessed data.
+         *
          * @param redisConnectionFactory Redis connection factory
-         * @return Configured RedisCacheManager with externalized TTL values
+         * @param objectMapper the app's shared Jackson mapper
+         * @return Configured RedisCacheManager with externalized TTL
+         *         values
          */
         @Bean
-        @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(name = "spring.cache.type", havingValue = "redis")
-        public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
-                // Redis serializer needs a dedicated ObjectMapper copy with default typing enabled
-                // so that GenericJackson2JsonRedisSerializer embeds @class type information in the
-                // JSON. Without it, deserialization returns LinkedHashMap instead of the entity class.
-                // We copy the app ObjectMapper to retain all registered modules (Java time, etc.)
-                // rather than creating a new instance.
+        @ConditionalOnProperty(name = "spring.cache.type",
+                        havingValue = "redis")
+        public RedisCacheManager cacheManager(
+                        RedisConnectionFactory redisConnectionFactory,
+                        ObjectMapper objectMapper) {
+                // Redis serializer needs a dedicated ObjectMapper copy
+                // with default typing enabled so that
+                // GenericJackson2JsonRedisSerializer embeds @class type
+                // information in the JSON. Without it, deserialization
+                // returns LinkedHashMap instead of the entity class.
+                // We copy the app ObjectMapper to retain all registered
+                // modules (Java time, etc.) rather than creating a new
+                // instance.
+                var validator = BasicPolymorphicTypeValidator.builder()
+                                .allowIfBaseType(Object.class)
+                                .build();
                 ObjectMapper redisMapper = objectMapper.copy()
-                                .activateDefaultTyping(
-                                                BasicPolymorphicTypeValidator.builder()
-                                                                .allowIfBaseType(Object.class)
-                                                                .build(),
-                                                ObjectMapper.DefaultTyping.NON_FINAL);
-                var jsonSerializer = SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(redisMapper));
-                RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                                .activateDefaultTyping(validator,
+                                                ObjectMapper.DefaultTyping
+                                                                .NON_FINAL);
+                var jsonSerializer = SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer(
+                                                redisMapper));
+                RedisCacheConfiguration defaultConfig =
+                                RedisCacheConfiguration.defaultCacheConfig()
                                 .serializeValuesWith(jsonSerializer)
                                 .entryTtl(Duration.ofMinutes(10))
                                 .disableCachingNullValues();
 
+                RedisCacheConfiguration products =
+                                regionConfig(jsonSerializer, productsTtlMs);
+                RedisCacheConfiguration categories =
+                                regionConfig(jsonSerializer, categoriesTtlMs);
+                RedisCacheConfiguration auditLogs =
+                                regionConfig(jsonSerializer, auditLogsTtlMs);
+                RedisCacheConfiguration userPermissions = regionConfig(
+                                jsonSerializer, userPermissionsTtlMs);
+                RedisCacheConfiguration inventoryItems = regionConfig(
+                                jsonSerializer, inventoryItemsTtlMs);
+                RedisCacheConfiguration relatedProducts =
+                                regionConfig(jsonSerializer, relatedTtlMs);
+                RedisCacheConfiguration rateLimitStats = regionConfig(
+                                jsonSerializer, rateLimitStatsTtlMs);
+                RedisCacheConfiguration orders =
+                                regionConfig(jsonSerializer, ordersTtlMs);
+                RedisCacheConfiguration users =
+                                regionConfig(jsonSerializer, usersTtlMs);
+
                 return RedisCacheManager.builder(redisConnectionFactory)
                                 .cacheDefaults(defaultConfig)
-                                // Products cache: TTL from application.properties
-                                .withCacheConfiguration("products",
-                                                RedisCacheConfiguration.defaultCacheConfig()
-                                                                .serializeValuesWith(jsonSerializer)
-                                                                .entryTtl(Duration.ofMillis(productsTtlMs))
-                                                                .disableCachingNullValues())
-                                // Categories cache: TTL from application.properties
+                                .withCacheConfiguration("products", products)
                                 .withCacheConfiguration("categories",
-                                                RedisCacheConfiguration.defaultCacheConfig()
-                                                                .serializeValuesWith(jsonSerializer)
-                                                                .entryTtl(Duration.ofMillis(categoriesTtlMs))
-                                                                .disableCachingNullValues())
-                                // Audit logs cache: TTL from application.properties
+                                                categories)
                                 .withCacheConfiguration("auditLogs",
-                                                RedisCacheConfiguration.defaultCacheConfig()
-                                                                .serializeValuesWith(jsonSerializer)
-                                                                .entryTtl(Duration.ofMillis(auditLogsTtlMs))
-                                                                .disableCachingNullValues())
-                                // User permissions cache: TTL from application.properties
+                                                auditLogs)
                                 .withCacheConfiguration("userPermissions",
-                                                RedisCacheConfiguration.defaultCacheConfig()
-                                                                .serializeValuesWith(jsonSerializer)
-                                                                .entryTtl(Duration.ofMillis(userPermissionsTtlMs))
-                                                                .disableCachingNullValues())
-                                // Inventory items cache: TTL from application.properties
+                                                userPermissions)
                                 .withCacheConfiguration("inventoryItems",
-                                                RedisCacheConfiguration.defaultCacheConfig()
-                                                                .serializeValuesWith(jsonSerializer)
-                                                                .entryTtl(Duration.ofMillis(inventoryItemsTtlMs))
-                                                                .disableCachingNullValues())
-                                // Related products cache: TTL from properties
+                                                inventoryItems)
                                 .withCacheConfiguration("relatedProducts",
-                                                regionConfig(jsonSerializer,
-                                                                relatedTtlMs))
-                                // Rate limit statistics cache: TTL from application.properties
+                                                relatedProducts)
                                 .withCacheConfiguration("rateLimitStats",
-                                                RedisCacheConfiguration.defaultCacheConfig()
-                                                                .serializeValuesWith(jsonSerializer)
-                                                                .entryTtl(Duration.ofMillis(rateLimitStatsTtlMs))
-                                                                .disableCachingNullValues())
-                                // Orders cache: TTL from application.properties
-                                .withCacheConfiguration("orders",
-                                                RedisCacheConfiguration.defaultCacheConfig()
-                                                                .serializeValuesWith(jsonSerializer)
-                                                                .entryTtl(Duration.ofMillis(ordersTtlMs))
-                                                                .disableCachingNullValues())
-                                // Users cache: TTL from application.properties
-                                .withCacheConfiguration("users",
-                                                RedisCacheConfiguration.defaultCacheConfig()
-                                                                .serializeValuesWith(jsonSerializer)
-                                                                .entryTtl(Duration.ofMillis(usersTtlMs))
-                                                                .disableCachingNullValues())
+                                                rateLimitStats)
+                                .withCacheConfiguration("orders", orders)
+                                .withCacheConfiguration("users", users)
                                 .build();
         }
 
@@ -154,7 +167,8 @@ public class CacheConfig {
          * Builds a {@link RedisCacheConfiguration} for one cache region
          * (PROD-04, #84).
          *
-         * @param jsonSerializer the shared value serializer for all regions
+         * @param jsonSerializer the shared value serializer for all
+         *                       regions
          * @param ttlMs the region's TTL in milliseconds
          * @return the region's cache configuration
          */

--- a/backend/src/main/java/com/example/buildnest_ecommerce/config/GracefulCacheErrorHandler.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/config/GracefulCacheErrorHandler.java
@@ -1,0 +1,75 @@
+package com.example.buildnest_ecommerce.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.data.redis.RedisConnectionFailureException;
+
+/**
+ * Falls through to the underlying method (or a no-op) instead of
+ * propagating on a Redis <em>connection</em> failure, matching
+ * {@code resilience4j.md}'s "Redis (cache) — Fall through to database —
+ * do not throw" fallback table. Spring's {@code @EnableCaching}
+ * auto-detects the single {@link CacheErrorHandler} bean of this type
+ * without needing a {@code CachingConfigurer}.
+ *
+ * <p>Only exceptions caused by a {@link RedisConnectionFailureException}
+ * are swallowed. Any other cache exception (e.g. a serialization
+ * failure indicating real data corruption) is rethrown, per issue #650's
+ * acceptance criterion that this must not mask genuine cache-poisoning
+ * bugs.
+ */
+@Slf4j
+public class GracefulCacheErrorHandler implements CacheErrorHandler {
+
+    @Override
+    public void handleCacheGetError(
+            RuntimeException exception, Cache cache, Object key) {
+        handle(exception, "GET", cache.getName());
+    }
+
+    @Override
+    public void handleCachePutError(
+            RuntimeException exception, Cache cache, Object key,
+            Object value) {
+        handle(exception, "PUT", cache.getName());
+    }
+
+    @Override
+    public void handleCacheEvictError(
+            RuntimeException exception, Cache cache, Object key) {
+        handle(exception, "EVICT", cache.getName());
+    }
+
+    @Override
+    public void handleCacheClearError(
+            RuntimeException exception, Cache cache) {
+        handle(exception, "CLEAR", cache.getName());
+    }
+
+    private void handle(
+            RuntimeException exception, String operation,
+            String cacheName) {
+        if (isConnectionFailure(exception)) {
+            log.debug(
+                    "Redis unreachable during cache {} on '{}', "
+                            + "falling through: {}",
+                    operation, cacheName, exception.getMessage());
+            return;
+        }
+        log.error(
+                "Cache {} failed on '{}' due to a non-connection error",
+                operation, cacheName, exception);
+        throw exception;
+    }
+
+    private boolean isConnectionFailure(Throwable exception) {
+        for (Throwable cause = exception; cause != null;
+                cause = cause.getCause()) {
+            if (cause instanceof RedisConnectionFailureException) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/backend/src/test/java/com/example/buildnest_ecommerce/config/CacheRedisUnavailableIntegrationTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/config/CacheRedisUnavailableIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.example.buildnest_ecommerce.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce
+                .LettuceConnectionFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Real-Spring-proxy test for issue #650 (AC #3): a
+ * {@code @Cacheable}-annotated method must still return real data — not
+ * throw — when Redis is genuinely unreachable. Uses a real
+ * {@code @EnableCaching} AOP proxy over a
+ * {@link LettuceConnectionFactory} pointed at a closed local port
+ * (fast TCP refusal, no live Redis needed) rather than mocks, since a
+ * mocked {@code CacheManager} can't exercise the real cache-aspect →
+ * {@link CacheErrorHandler} dispatch this fix relies on (testing.md's
+ * framework/mapping-level real-context tier).
+ */
+class CacheRedisUnavailableIntegrationTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    @DisplayName("cached method returns real data instead of throwing "
+            + "when Redis is unreachable")
+    void cachedMethodFallsThroughWhenRedisUnreachable() {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        DummyCachedService service =
+                context.getBean(DummyCachedService.class);
+
+        assertThatCode(() -> {
+            String first = service.getValue("k1");
+            assertThat(first).isEqualTo("real-data-k1");
+        }).doesNotThrowAnyException();
+
+        // A second call (would be a cache hit if Redis were up) must
+        // also fall through and still return real data, not a stale
+        // or thrown result.
+        String second = service.getValue("k1");
+        assertThat(second).isEqualTo("real-data-k1");
+    }
+
+    @Configuration
+    @EnableCaching
+    static class TestConfig implements CachingConfigurer {
+
+        @Bean
+        RedisConnectionFactory redisConnectionFactory() {
+            // Port 1 on localhost refuses the TCP connection almost
+            // instantly (no live Redis process required), simulating
+            // "Redis is down" without a slow connect timeout.
+            LettuceConnectionFactory factory =
+                    new LettuceConnectionFactory("localhost", 1);
+            factory.afterPropertiesSet();
+            return factory;
+        }
+
+        // Must come via CachingConfigurer, not a plain @Bean -- see
+        // CacheConfig#errorHandler's own javadoc for why.
+        @Override
+        public CacheErrorHandler errorHandler() {
+            return new GracefulCacheErrorHandler();
+        }
+
+        @Bean
+        CacheManager cacheManager(RedisConnectionFactory factory) {
+            return RedisCacheManager.builder(factory).build();
+        }
+
+        @Bean
+        DummyCachedService dummyCachedService() {
+            return new DummyCachedService();
+        }
+    }
+
+    @Service
+    static class DummyCachedService {
+        @Cacheable("testCache")
+        public String getValue(String key) {
+            return "real-data-" + key;
+        }
+    }
+}

--- a/backend/src/test/java/com/example/buildnest_ecommerce/config/GracefulCacheErrorHandlerTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/config/GracefulCacheErrorHandlerTest.java
@@ -1,0 +1,87 @@
+package com.example.buildnest_ecommerce.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.serializer.SerializationException;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link GracefulCacheErrorHandler} (#650): a Redis
+ * connection failure must be swallowed (fall through), while any other
+ * cache exception (e.g. a serialization failure indicating real data
+ * corruption, see #651) must still propagate.
+ */
+class GracefulCacheErrorHandlerTest {
+
+    private final GracefulCacheErrorHandler handler =
+            new GracefulCacheErrorHandler();
+
+    @Test
+    @DisplayName("GET swallows a RedisConnectionFailureException")
+    void getSwallowsConnectionFailure() {
+        Cache cache = mock(Cache.class);
+        when(cache.getName()).thenReturn("products");
+        RedisConnectionFailureException ex =
+                new RedisConnectionFailureException("down");
+
+        assertThatCode(() -> handler.handleCacheGetError(ex, cache, 1L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("PUT swallows a wrapped RedisConnectionFailureException")
+    void putSwallowsWrappedConnectionFailure() {
+        Cache cache = mock(Cache.class);
+        when(cache.getName()).thenReturn("products");
+        RuntimeException wrapped = new RuntimeException("wrapper",
+                new RedisConnectionFailureException("down"));
+
+        assertThatCode(() -> handler.handleCachePutError(
+                wrapped, cache, 1L, "value"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("EVICT swallows a RedisConnectionFailureException")
+    void evictSwallowsConnectionFailure() {
+        Cache cache = mock(Cache.class);
+        when(cache.getName()).thenReturn("products");
+        RedisConnectionFailureException ex =
+                new RedisConnectionFailureException("down");
+
+        assertThatCode(() -> handler.handleCacheEvictError(ex, cache, 1L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("CLEAR swallows a RedisConnectionFailureException")
+    void clearSwallowsConnectionFailure() {
+        Cache cache = mock(Cache.class);
+        when(cache.getName()).thenReturn("products");
+        RedisConnectionFailureException ex =
+                new RedisConnectionFailureException("down");
+
+        assertThatCode(() -> handler.handleCacheClearError(ex, cache))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("GET rethrows a non-connection exception "
+            + "(serialization/corruption)")
+    void getRethrowsNonConnectionFailure() {
+        Cache cache = mock(Cache.class);
+        when(cache.getName()).thenReturn("products");
+        SerializationException ex =
+                new SerializationException("corrupt payload");
+
+        assertThatThrownBy(() ->
+                handler.handleCacheGetError(ex, cache, 1L))
+                .isSameAs(ex);
+    }
+}

--- a/docs/SDLC-docs/design/software-design-description.md
+++ b/docs/SDLC-docs/design/software-design-description.md
@@ -10,7 +10,7 @@
 | :--- | :--- |
 | **Document Title** | Software Design Description (SDD) |
 | **Document ID** | SDD-BUILDNEST-001 |
-| **Version** | 4.14 |
+| **Version** | 4.15 |
 | **Date** | 2026-08-02 IST |
 | **Status** | Controlled — Under Review |
 | **Classification** | Internal Use |
@@ -51,6 +51,7 @@
 | 4.13 | 2026-07-30 IST | Software Architect | Periodic 15-issue SDLC documentation sync (overdue — last performed at #452/#458, 2026-07-17; 53 issues closed since). Recomputed all 13 rows of §4.2.3's Component Statistics table directly via the `find`/`grep` commands the table itself cites — every metric had drifted upward since the 2026-07-17 baseline (e.g. 352→383 source files, 38→44 controllers, 28→33 repositories, 218→245 endpoint mappings) as the Ph-3 marketplace-pivot (seller/district features, #553-#564) shipped real code with no single issue's own scope covering a re-verification. MySQL 8.2/Redis 7/Elasticsearch 8.17 stack claims re-checked against `docker-compose.yml`'s active service definitions — still accurate. `Related SRS` updated 5.6 → 5.8 (2 intervening bumps, #110/#111, never propagated here) | Pending |
 | 4.14 | 2026-08-02 IST | Software Architect | #647: retired only the browser-driven Selenium E2E class (`E2ETest.java`) now that `playwright-e2e` demonstrated 3/3 real green runs on `master`. Mid-implementation correction: an initial pass wrongly deleted the whole `e2e/` package, including the separate RestAssured API E2E suite (`ProductApiTest`/`OrderApiTest`/`CartApiTest`, still real, still `@Tag("e2e")`-tagged) that TIR-01 actually governs — caught before commit, restored, and this table's row corrected to describe the current (not assumed-retired) state | Pending |
 | 4.7 | 2026-07-28 17:00 IST | Software Architect | FR-SEL-07 (#558): new `SellerReview` entity/table (`seller_review`), mirroring `ProductReview` but scoped by the seller's `User.id`. Added to §4.5.1's ER diagram and §4.5.2's entity table. Same DTO-exposure gap recurred as #581's `orderGroupId` fix — `OrderResponseDTO` needed a new `sellerId` field so the frontend's `SellerReviewPanel` (surfaced from a delivered order's detail view) could link an order to the seller being rated; populated in the same two mapping methods (`OrderServiceImpl.mapToResponseDTO`, `CheckoutServiceImpl`'s equivalent) | Pending |
+| 4.15 | 2026-08-02 IST | Software Architect | #650: corrected §5.3.1's `redis-circuit-breaker` row — it never actually protected declarative `@Cacheable`/`@CacheEvict` calls, only manually-wrapped `RedisTemplate` usage (rate limiting); the `@Cacheable` proxy path had zero resilience coverage until this issue added a `GracefulCacheErrorHandler` (registered via `CacheConfig implements CachingConfigurer#errorHandler()`, since `@EnableCaching` does not auto-detect a plain `CacheErrorHandler` bean by type). Added a clarifying paragraph documenting the fix and the scope correction | Pending |
 | 4.5 | 2026-07-26 09:00 IST | Software Architect | Final sub-issue of #557/FR-SEL-06: added `SellerOrderController`/`OrderServiceImpl`'s new seller-scoped list/detail/status methods, using a new `OrderRepository.findBySellerId`/`findByIdAndSellerId` `EXISTS`-subquery (`Order` has no direct seller reference; ownership derived transitively via `OrderItem.product.seller`) — mirrors #555's `SellerProductController`/#556's `SellerInventoryController` ownership-scoping pattern. All three FR-SEL-06 sub-issues (#578/#579/#580) now closed. **Not addressed in this revision**: §4.7.3's API Endpoint Catalogue does not yet list any of the three sellers' controllers (`SellerProductController`/`SellerInventoryController`/`SellerOrderController`) — this gap was already surfaced and filed as its own follow-up (#576) during #556's closure; not duplicated here | Pending |
 
 ### Document Approval
@@ -1626,8 +1627,17 @@ Bucket4j token-bucket strategy backed by Redis:
 
 | Instance | Protects | Failure Threshold | Slow Call Threshold | Wait Duration |
 | :--- | :--- | :--- | :--- | :--- |
-| `redis-circuit-breaker` | Redis cache and rate limit calls | **70%** | — | 30 seconds |
+| `redis-circuit-breaker` | Manually-wrapped Redis calls (rate limiting, `RateLimiterService`) | **70%** | — | 30 seconds |
 | `database-circuit-breaker` | All JPA / JDBC calls | **50%** | 50% > 8 s | 60 seconds |
+
+Declarative `@Cacheable`/`@CacheEvict` calls (`CacheConfig`, `ProductServiceImpl`
+and siblings) are **not** covered by `redis-circuit-breaker` — that instance
+only wraps manual `RedisTemplate` usage. The cache-annotation proxy path is
+instead protected by `GracefulCacheErrorHandler`, registered via
+`CacheConfig implements CachingConfigurer#errorHandler()` (#650): it falls
+through to the underlying method on a `RedisConnectionFailureException`
+without throwing, while still rethrowing genuine serialization/corruption
+errors (see #651).
 
 #### 5.3.2 Time Limiter Configuration
 


### PR DESCRIPTION
## Summary
- `@Cacheable`/`@CacheEvict` never had resilience protection despite `resilience4j.md`'s stated "Redis — fall through to database, do not throw" fallback — that promise only ever held for manually circuit-breaker-wrapped Redis usage. A `RedisConnectionFailureException` propagated through the cache-aspect proxy (`ProductServiceImpl#getProductById` and every other `@Cacheable`/`@CacheEvict` site) and surfaced as a false 404.
- Adds `GracefulCacheErrorHandler`, wired via `CacheConfig implements CachingConfigurer#errorHandler()` — confirmed via decompiling `AbstractCachingConfiguration`/`ProxyCachingConfiguration` that `@EnableCaching` does **not** auto-detect a plain `CacheErrorHandler` bean by type, only one supplied through `CachingConfigurer`.
- Only a `RedisConnectionFailureException` (direct or wrapped as a cause) is swallowed; any other cache exception — e.g. a serialization failure indicating real data corruption (#651) — still propagates, per the issue's AC #4.
- Rewrapped `CacheConfig.java` to satisfy this repo's CheckStyle line-length ratchet while touching the file (pre-existing violations, unrelated to this fix's own lines).

Closes #650

## Test plan
- [x] `GracefulCacheErrorHandlerTest` — unit test asserting GET/PUT/EVICT/CLEAR all swallow a `RedisConnectionFailureException` (direct and wrapped), and GET rethrows a `SerializationException`.
- [x] `CacheRedisUnavailableIntegrationTest` — real `@EnableCaching` AOP proxy over a `LettuceConnectionFactory` pointed at an unreachable port; asserts a `@Cacheable` method still returns real data instead of throwing.
- [x] `CacheConfigTest` (existing) — regression-verified, still green after the `regionConfig`-based rewrite.
- [x] Full backend suite (`./mvnw test`) — green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)