### PR TITLE
fix(test): root-cause and fix 3 deferred Playwright E2E scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,23 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
   to do with Selenium or browsers.
 
 ### Fixed
+- 3 deferred Playwright E2E scenarios root-caused and un-deferred (#652,
+  removing #117's `test.fixme()` markers): (1) the "Continue to Payment"
+  checkout gap (`happy-path.spec.ts`'s 2nd test, `error-paths.spec.ts`'s
+  payment-failure test) was not a district-matching bug as originally
+  suspected — the `playwright-e2e` CI job starts the backend with
+  `--spring.jpa.hibernate.ddl-auto=create-drop`, which regenerates every
+  entity-mapped table from JPA annotations after Liquibase runs, wiping
+  the Liquibase-seeded default shipping method (`20260704-013-seed-
+  default-shipping-method.xml`, #304) before `E2ESeedDataRunner`
+  executes — leaving zero active shipping methods and a permanently
+  disabled Continue button. Fixed by seeding a default `ShippingMethod`
+  in `E2ESeedDataRunner` alongside the existing product/inventory seed.
+  (2) The out-of-stock scenario's `page.route()` interception spread
+  `stockQuantity: 0` onto the `ApiResponse` envelope root instead of
+  `body.data` (where `Product.getStockQuantity()` actually serializes),
+  so the real in-stock value passed through unmodified. Fixed the test's
+  own interception to mutate the correct nesting level.
 - `@Cacheable` not gracefully degrading when Redis is down (#650,
   discovered via #117's CI investigation): `RedisConnectionFailureException`
   propagated through `ProductServiceImpl#getProductById` (and every other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,23 +65,35 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
   to do with Selenium or browsers.
 
 ### Fixed
-- 3 deferred Playwright E2E scenarios root-caused and un-deferred (#652,
-  removing #117's `test.fixme()` markers): (1) the "Continue to Payment"
-  checkout gap (`happy-path.spec.ts`'s 2nd test, `error-paths.spec.ts`'s
-  payment-failure test) was not a district-matching bug as originally
-  suspected — the `playwright-e2e` CI job starts the backend with
+- 3 deferred Playwright E2E scenarios investigated (#652); 1 fully fixed
+  and un-deferred, 2 root-caused two layers deep and re-deferred behind a
+  newly-discovered, separately-tracked blocker (#662): (1) the out-of-
+  stock scenario's `page.route()` interception spread `stockQuantity: 0`
+  onto the `ApiResponse` envelope root instead of `body.data` (where
+  `Product.getStockQuantity()` actually serializes), so the real in-stock
+  value passed through unmodified — fixed the test's own interception to
+  mutate the correct nesting level; `test.fixme()` removed, now passing
+  in CI. (2) The "Continue to Payment" checkout gap (`happy-path.spec.ts`'s
+  2nd test, `error-paths.spec.ts`'s payment-failure test) was not a
+  district-matching bug as originally suspected — two independent causes,
+  both fixed: (a) the `playwright-e2e` CI job starts the backend with
   `--spring.jpa.hibernate.ddl-auto=create-drop`, which regenerates every
   entity-mapped table from JPA annotations after Liquibase runs, wiping
   the Liquibase-seeded default shipping method (`20260704-013-seed-
   default-shipping-method.xml`, #304) before `E2ESeedDataRunner`
-  executes — leaving zero active shipping methods and a permanently
-  disabled Continue button. Fixed by seeding a default `ShippingMethod`
-  in `E2ESeedDataRunner` alongside the existing product/inventory seed.
-  (2) The out-of-stock scenario's `page.route()` interception spread
-  `stockQuantity: 0` onto the `ApiResponse` envelope root instead of
-  `body.data` (where `Product.getStockQuantity()` actually serializes),
-  so the real in-stock value passed through unmodified. Fixed the test's
-  own interception to mutate the correct nesting level.
+  executes — fixed by seeding a default `ShippingMethod` in
+  `E2ESeedDataRunner`; (b) `ShippingStep`'s `selected` state was
+  initialized from the `options` prop in a `useState` lazy initializer,
+  which only runs once at mount — since `options` populates
+  asynchronously after mount, `selected` stayed `null` forever even once
+  shipping options loaded, so clicking Continue silently no-opped instead
+  of calling the API — fixed via a `useEffect` that syncs the default
+  selection once options arrive. Fixing both exposed a third, previously
+  unreachable blocker: the CI job's Razorpay credentials are placeholder
+  strings, so `initiatePayment` now genuinely fails authentication before
+  the Pay button renders — re-deferred via `test.fixme()` as its own
+  issue (#662), since it needs a real architectural decision (mock vs.
+  real sandbox credentials), not a quick fix.
 - `@Cacheable` not gracefully degrading when Redis is down (#650,
   discovered via #117's CI investigation): `RedisConnectionFailureException`
   propagated through `ProductServiceImpl#getProductById` (and every other

--- a/backend/src/main/java/com/example/buildnest_ecommerce/e2e/E2ESeedDataRunner.java
+++ b/backend/src/main/java/com/example/buildnest_ecommerce/e2e/E2ESeedDataRunner.java
@@ -4,9 +4,11 @@ import com.example.buildnest_ecommerce.model.entity.Category;
 import com.example.buildnest_ecommerce.model.entity.Inventory;
 import com.example.buildnest_ecommerce.model.entity.InventoryStatus;
 import com.example.buildnest_ecommerce.model.entity.Product;
+import com.example.buildnest_ecommerce.model.entity.ShippingMethod;
 import com.example.buildnest_ecommerce.repository.CategoryRepository;
 import com.example.buildnest_ecommerce.repository.InventoryRepository;
 import com.example.buildnest_ecommerce.repository.ProductRepository;
+import com.example.buildnest_ecommerce.repository.ShippingMethodRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -33,6 +35,18 @@ import java.time.LocalDateTime;
  * Spring profile or deployment ever sets {@code e2e.seed.enabled=true}.
  * Mirrors {@code BaseApiTest#seedProduct} (repository-based, not raw
  * SQL, to avoid guessing Hibernate's generated column names).
+ *
+ * <p>Also seeds a default active {@code ShippingMethod} (#652): the CI
+ * job that runs this runner starts the backend with
+ * {@code --spring.jpa.hibernate.ddl-auto=create-drop}, which regenerates
+ * every entity-mapped table from JPA annotations after Liquibase has
+ * already run — wiping the Liquibase-seeded default shipping method
+ * ({@code 20260704-013-seed-default-shipping-method.xml}, #304) before
+ * this {@code ApplicationRunner} executes (see the
+ * {@code liquibase-seed-verification-under-hibernate-create-drop.md}
+ * wiki lesson). Without it, {@code getShippingOptions} returns an empty
+ * list and the checkout {@code ShippingStep}'s Continue button stays
+ * permanently disabled in this CI job.
  */
 @Slf4j
 @Component
@@ -44,6 +58,7 @@ public class E2ESeedDataRunner implements ApplicationRunner {
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
     private final InventoryRepository inventoryRepository;
+    private final ShippingMethodRepository shippingMethodRepository;
 
     @Override
     @Transactional
@@ -77,5 +92,22 @@ public class E2ESeedDataRunner implements ApplicationRunner {
         inventoryRepository.save(inventory);
         log.info("E2ESeedDataRunner: seeded product id={} sku={}",
                 saved.getId(), saved.getSku());
+
+        if (shippingMethodRepository.findAllByIsActiveTrue().isEmpty()) {
+            ShippingMethod method = new ShippingMethod();
+            method.setName("Standard Delivery");
+            method.setDescription(
+                    "Flat-rate delivery to any serviceable postal code");
+            method.setBaseCost(new BigDecimal("50.00"));
+            method.setCostPerKg(new BigDecimal("10.00"));
+            method.setEstimatedDaysMin(3);
+            method.setEstimatedDaysMax(7);
+            method.setIsActive(true);
+            method.setCreatedAt(LocalDateTime.now());
+            method.setUpdatedAt(LocalDateTime.now());
+            ShippingMethod savedMethod = shippingMethodRepository.save(method);
+            log.info("E2ESeedDataRunner: seeded shipping method id={}",
+                    savedMethod.getId());
+        }
     }
 }

--- a/backend/src/test/java/com/example/buildnest_ecommerce/e2e/E2ESeedDataRunnerTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/e2e/E2ESeedDataRunnerTest.java
@@ -4,9 +4,11 @@ import com.example.buildnest_ecommerce.model.entity.Category;
 import com.example.buildnest_ecommerce.model.entity.Inventory;
 import com.example.buildnest_ecommerce.model.entity.InventoryStatus;
 import com.example.buildnest_ecommerce.model.entity.Product;
+import com.example.buildnest_ecommerce.model.entity.ShippingMethod;
 import com.example.buildnest_ecommerce.repository.CategoryRepository;
 import com.example.buildnest_ecommerce.repository.InventoryRepository;
 import com.example.buildnest_ecommerce.repository.ProductRepository;
+import com.example.buildnest_ecommerce.repository.ShippingMethodRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,10 +17,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +40,9 @@ class E2ESeedDataRunnerTest {
 
     @Mock
     private InventoryRepository inventoryRepository;
+
+    @Mock
+    private ShippingMethodRepository shippingMethodRepository;
 
     @InjectMocks
     private E2ESeedDataRunner runner;
@@ -55,6 +64,13 @@ class E2ESeedDataRunnerTest {
         when(productRepository.save(any(Product.class)))
                 .thenReturn(savedProduct);
 
+        when(shippingMethodRepository.findAllByIsActiveTrue())
+                .thenReturn(Collections.emptyList());
+        ShippingMethod savedMethod = new ShippingMethod();
+        savedMethod.setId(4L);
+        when(shippingMethodRepository.save(any(ShippingMethod.class)))
+                .thenReturn(savedMethod);
+
         runner.run(null);
 
         ArgumentCaptor<Product> productCaptor =
@@ -70,6 +86,14 @@ class E2ESeedDataRunnerTest {
         assertEquals(InventoryStatus.IN_STOCK,
                 inventoryCaptor.getValue().getStatus());
         assertEquals(100, inventoryCaptor.getValue().getQuantityInStock());
+
+        ArgumentCaptor<ShippingMethod> shippingCaptor =
+                ArgumentCaptor.forClass(ShippingMethod.class);
+        verify(shippingMethodRepository).save(shippingCaptor.capture());
+        assertEquals("Standard Delivery", shippingCaptor.getValue().getName());
+        assertEquals(new BigDecimal("50.00"),
+                shippingCaptor.getValue().getBaseCost());
+        assertEquals(Boolean.TRUE, shippingCaptor.getValue().getIsActive());
     }
 
     @Test
@@ -86,14 +110,21 @@ class E2ESeedDataRunnerTest {
         when(productRepository.save(any(Product.class)))
                 .thenReturn(savedProduct);
 
+        ShippingMethod existingMethod = new ShippingMethod();
+        existingMethod.setId(5L);
+        when(shippingMethodRepository.findAllByIsActiveTrue())
+                .thenReturn(List.of(existingMethod));
+
         runner.run(null);
 
-        verify(categoryRepository, org.mockito.Mockito.never())
-                .save(any(Category.class));
+        verify(categoryRepository, never()).save(any(Category.class));
 
         ArgumentCaptor<Product> productCaptor =
                 ArgumentCaptor.forClass(Product.class);
         verify(productRepository).save(productCaptor.capture());
         assertEquals(existingCategory, productCaptor.getValue().getCategory());
+
+        verify(shippingMethodRepository, never())
+                .save(any(ShippingMethod.class));
     }
 }

--- a/frontend/e2e/error-paths.spec.ts
+++ b/frontend/e2e/error-paths.spec.ts
@@ -12,16 +12,16 @@ import { fillAddressStep } from './fixtures';
 // calling registerAndLogin — RateLimitHeaderInterceptor's hardcoded AUTH_LIMIT (5 requests per
 // window on any /api/auth/** path, not property-configurable) is exhausted by 3 independent
 // register+login pairs (6 requests) once Redis makes rate limiting actually enforceable (#117).
-// Both scenarios below are deferred via test.fixme() pending #652 — not yet reliably green in
-// CI: the out-of-stock scenario's "Out of Stock" text doesn't render even though the add-to-cart
-// button correctly disappears, and the payment-failure scenario depends on reaching the payment
-// step, which is blocked by the same checkout gap tracked in #652. Not root-caused yet; deferred
-// rather than blocking #117 further after this many CI round-trips already fixed 5 other real,
-// previously-hidden bugs (#647/#649/#650/#651) along the way.
+// Both scenarios were deferred via test.fixme() pending #652; root-caused and fixed:
+// the out-of-stock scenario's route interception mutated the ApiResponse envelope root instead
+// of body.data (where Product.getStockQuantity() actually serializes), so the real stock value
+// passed through untouched; the payment-failure scenario was blocked by the checkout gap, fixed
+// by seeding a default ShippingMethod in E2ESeedDataRunner (ddl-auto=create-drop was wiping the
+// Liquibase-seeded one after Liquibase ran but before this ApplicationRunner executed).
 test.use({ storageState: 'e2e/.auth/shared-user.json' });
 
 test.describe('Critical error paths', () => {
-  test.fixme('out-of-stock product cannot be added to cart', async ({ page }) => {
+  test('out-of-stock product cannot be added to cart', async ({ page }) => {
     await page.goto('/products');
     await expect(page.getByTestId('product-grid').locator('a').first()).toBeVisible({ timeout: 15_000 });
     const firstProductHref = await page.getByTestId('product-grid').locator('a').first().getAttribute('href');
@@ -31,9 +31,12 @@ test.describe('Critical error paths', () => {
     await page.route(`**/api/public/products/${productId}`, async route => {
       const response = await route.fetch();
       const body = await response.json();
+      // stockQuantity lives on the unwrapped product (body.data), not on the
+      // ApiResponse envelope itself — mutating the envelope root leaves the
+      // real value untouched once the frontend unwraps `data` (#652).
       await route.fulfill({
         response,
-        json: { ...body, stockQuantity: 0 },
+        json: { ...body, data: { ...body.data, stockQuantity: 0 } },
       });
     });
 
@@ -42,7 +45,7 @@ test.describe('Critical error paths', () => {
     await expect(page.getByText(/out of stock/i)).toBeVisible({ timeout: 15_000 });
   });
 
-  test.fixme('a failed order confirmation surfaces an error instead of navigating away', async ({ page }) => {
+  test('a failed order confirmation surfaces an error instead of navigating away', async ({ page }) => {
     await page.goto('/products');
     await expect(page.getByTestId('product-grid').locator('a').first()).toBeVisible({ timeout: 15_000 });
     await page.getByTestId('product-grid').locator('a').first().click();

--- a/frontend/e2e/error-paths.spec.ts
+++ b/frontend/e2e/error-paths.spec.ts
@@ -12,12 +12,18 @@ import { fillAddressStep } from './fixtures';
 // calling registerAndLogin — RateLimitHeaderInterceptor's hardcoded AUTH_LIMIT (5 requests per
 // window on any /api/auth/** path, not property-configurable) is exhausted by 3 independent
 // register+login pairs (6 requests) once Redis makes rate limiting actually enforceable (#117).
-// Both scenarios were deferred via test.fixme() pending #652; root-caused and fixed:
-// the out-of-stock scenario's route interception mutated the ApiResponse envelope root instead
+// Both scenarios were deferred via test.fixme() pending #652. The out-of-stock scenario is
+// root-caused and fixed: its route interception mutated the ApiResponse envelope root instead
 // of body.data (where Product.getStockQuantity() actually serializes), so the real stock value
-// passed through untouched; the payment-failure scenario was blocked by the checkout gap, fixed
-// by seeding a default ShippingMethod in E2ESeedDataRunner (ddl-auto=create-drop was wiping the
-// Liquibase-seeded one after Liquibase ran but before this ApplicationRunner executed).
+// passed through untouched. The payment-failure scenario's original checkout-gap blocker is also
+// fixed (a default ShippingMethod seeded in E2ESeedDataRunner, plus a ShippingStep useState-from-
+// async-prop bug) — but fixing those exposed a new, previously-unreachable blocker: this CI job's
+// Razorpay credentials (`--razorpay.key.id=test_key_id` etc.) are placeholder strings, not real
+// test-mode credentials, so `initiatePayment` now genuinely fails with
+// `RazorpayException: BAD_REQUEST_ERROR:Authentication failed` before the Pay button ever renders.
+// Re-deferred as its own tracked, separately-scoped issue (#662) rather than expanding #652
+// further — this needs a real architectural decision (mock vs. real sandbox credentials), not a
+// quick fix.
 test.use({ storageState: 'e2e/.auth/shared-user.json' });
 
 test.describe('Critical error paths', () => {
@@ -45,7 +51,7 @@ test.describe('Critical error paths', () => {
     await expect(page.getByText(/out of stock/i)).toBeVisible({ timeout: 15_000 });
   });
 
-  test('a failed order confirmation surfaces an error instead of navigating away', async ({ page }) => {
+  test.fixme('a failed order confirmation surfaces an error instead of navigating away', async ({ page }) => {
     await page.goto('/products');
     await expect(page.getByTestId('product-grid').locator('a').first()).toBeVisible({ timeout: 15_000 });
     await page.getByTestId('product-grid').locator('a').first().click();

--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -9,11 +9,12 @@ import { uniqueUser, registerAndLogin, fillAddressStep } from './fixtures';
 //
 // Split into two tests sharing one browser context (test.describe.serial + a describe-scoped
 // page) rather than one long test: register->browse->search->add-to-cart->cart passes reliably
-// in CI, but checkout->confirmation->order-history does not yet (the "Continue to Payment"
-// button stays disabled — likely a district/shipping-method matching gap for the test's
-// hardcoded address, not yet root-caused). Splitting preserves the reliable prefix as real,
-// asserted coverage instead of losing it to one flaky suffix. See #652 for the checkout-onward
-// gap, deferred rather than blocking this PR further.
+// in CI; checkout->confirmation->order-history was blocked by a checkout gap (#652, root-caused
+// and fixed: the CI job's ddl-auto=create-drop wiped the Liquibase-seeded default shipping
+// method after Liquibase ran but before E2ESeedDataRunner executed, leaving zero active shipping
+// methods and a permanently-disabled "Continue to Payment" button — not a district/shipping-
+// method matching issue). Kept as two tests since the split still preserves the reliable prefix
+// as independently asserted coverage.
 test.describe.serial('Full user journey', () => {
   let page: Page;
 
@@ -62,7 +63,7 @@ test.describe.serial('Full user journey', () => {
     });
   });
 
-  test.fixme('checkout, order confirmation, and order history', async () => {
+  test('checkout, order confirmation, and order history', async () => {
     await test.step('complete checkout: address, shipping, payment', async () => {
       await fillAddressStep(page);
 

--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -9,12 +9,16 @@ import { uniqueUser, registerAndLogin, fillAddressStep } from './fixtures';
 //
 // Split into two tests sharing one browser context (test.describe.serial + a describe-scoped
 // page) rather than one long test: register->browse->search->add-to-cart->cart passes reliably
-// in CI; checkout->confirmation->order-history was blocked by a checkout gap (#652, root-caused
-// and fixed: the CI job's ddl-auto=create-drop wiped the Liquibase-seeded default shipping
-// method after Liquibase ran but before E2ESeedDataRunner executed, leaving zero active shipping
-// methods and a permanently-disabled "Continue to Payment" button — not a district/shipping-
-// method matching issue). Kept as two tests since the split still preserves the reliable prefix
-// as independently asserted coverage.
+// in CI; checkout->confirmation->order-history was blocked by a checkout gap (#652), root-caused
+// and fixed across two layers — the CI job's ddl-auto=create-drop wiped the Liquibase-seeded
+// default shipping method after Liquibase ran but before E2ESeedDataRunner executed (not a
+// district-matching issue), and separately ShippingStep's `selected` state never updated once
+// options arrived asynchronously after mount. Fixing both exposed a new, previously-unreachable
+// blocker: this CI job's Razorpay credentials are placeholder strings, so `initiatePayment` now
+// genuinely fails authentication before the Pay button renders. Re-deferred via test.fixme() as
+// its own tracked issue (#662) — a real architectural decision (mock vs. real sandbox
+// credentials), not a quick fix. Kept as two tests since the split still preserves the reliable
+// prefix as independently asserted coverage.
 test.describe.serial('Full user journey', () => {
   let page: Page;
 
@@ -63,7 +67,7 @@ test.describe.serial('Full user journey', () => {
     });
   });
 
-  test('checkout, order confirmation, and order history', async () => {
+  test.fixme('checkout, order confirmation, and order history', async () => {
     await test.step('complete checkout: address, shipping, payment', async () => {
       await fillAddressStep(page);
 

--- a/frontend/src/components/checkout/ShippingStep.test.tsx
+++ b/frontend/src/components/checkout/ShippingStep.test.tsx
@@ -82,3 +82,50 @@ describe('ShippingStep coupon application', () => {
     expect(screen.queryByPlaceholderText('Enter coupon code')).not.toBeInTheDocument();
   });
 });
+
+describe('ShippingStep default selection (#652)', () => {
+  it('auto-selects the first option once it arrives asynchronously after mount', async () => {
+    const user = userEvent.setup();
+    const onApplyCoupon = vi.fn().mockResolvedValue(undefined);
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+
+    // Mirrors CheckoutPage's real usage: ShippingStep first mounts with an
+    // empty options array (fetch not yet resolved), then the parent
+    // re-renders with the fetched options once the request completes.
+    const { rerender } = render(
+      <ShippingStep
+        options={[]}
+        loading={false}
+        error={null}
+        session={baseSession}
+        couponLoading={false}
+        onApplyCoupon={onApplyCoupon}
+        onNext={onNext}
+        onBack={onBack}
+      />
+    );
+
+    rerender(
+      <ShippingStep
+        options={options}
+        loading={false}
+        error={null}
+        session={baseSession}
+        couponLoading={false}
+        onApplyCoupon={onApplyCoupon}
+        onNext={onNext}
+        onBack={onBack}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('radio')).toBeChecked()
+    );
+
+    await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+    expect(onNext).toHaveBeenCalledWith(options[0].id);
+    expect(screen.queryByText('Please select a shipping method')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/checkout/ShippingStep.tsx
+++ b/frontend/src/components/checkout/ShippingStep.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { CheckoutSession, ShippingOption } from '../../types';
 
 interface Props {
@@ -28,6 +28,16 @@ export function ShippingStep({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [couponCode, setCouponCode] = useState('');
   const [couponError, setCouponError] = useState<string | null>(null);
+
+  // `options` arrives asynchronously from the parent (fetched after mount),
+  // so the useState initializer above — which only runs once — can't select
+  // a default once options actually populate. Auto-select the first option
+  // whenever the list changes and nothing is selected yet (#652).
+  useEffect(() => {
+    if (selected === null && options.length > 0) {
+      setSelected(options[0].id);
+    }
+  }, [options, selected]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Fully fixed and un-deferred the out-of-stock scenario: the test's own `page.route()` interception mutated the `ApiResponse` envelope root instead of `body.data`, where `Product.getStockQuantity()` actually serializes — the real in-stock value passed through untouched.
- Root-caused the "Continue to Payment" checkout gap two layers deep — NOT a district-matching bug: (a) the `playwright-e2e` CI job's `ddl-auto=create-drop` wipes the Liquibase-seeded default shipping method after Liquibase runs but before `E2ESeedDataRunner` executes; fixed by seeding one there too. (b) `ShippingStep`'s `selected` state never updated once `options` arrived asynchronously after mount (a `useState` lazy-initializer bug, previously masked since the Continue button was always disabled anyway).
- Fixing both exposed a third, previously-unreachable blocker: the CI job's Razorpay credentials are placeholder strings, so `initiatePayment` now genuinely fails authentication. This is a real architectural decision (mock vs. real sandbox credentials), not a quick fix — filed as #662 and re-deferred those 2 scenarios via `test.fixme()` with updated reasoning.

Closes #652 (partially — AC1/AC2 root-caused; AC3 achieved for 1 of 3 scenarios, the other 2 re-deferred behind #662; AC4 satisfied — confirmed genuinely NOT a district-matching bug, filed #662 as the separate follow-up)

## Test plan
- [x] `E2ESeedDataRunnerTest` updated and passing (new ShippingMethodRepository mock + real assertions)
- [x] `ShippingStep.test.tsx` new regression test for the async-options auto-select bug, passing
- [x] CHANGELOG updated
- [x] `playwright-e2e` CI job: out-of-stock scenario passing; 2 remaining scenarios correctly re-deferred (not hidden — explicit `test.fixme()` + tracked issue #662)