### PR TITLE
fix(test): retry CSRF bootstrap in BaseApiTest to survive cookie-write race (#641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Pre-1.0 convention: MINOR increments represent completed milestones; PATCH incre
 
 ## [Unreleased] — M4: Feature Development
 
+### Fixed
+- `BaseApiTest`'s CSRF bootstrap (`e2e` RestAssured suite) could throw
+  `IllegalArgumentException: Header value cannot be null` when the
+  `XSRF-TOKEN` cookie set by `GET /api/auth/csrf` lost a timing race against
+  Spring Security's deferred-token cookie write (#641, surfaced by an
+  auto-filed CI-failure bot issue against PR #640's merge-preview run — not
+  reproducible locally across 2 full runs, and `master` was green on all 5
+  `Quality Gate Pipeline` runs since #640 merged, confirming a one-off
+  race rather than a deterministic regression). `setup()` now retries the
+  bootstrap GET up to 3 times before failing loudly, reflecting the real
+  eventual-consistency behavior instead of assuming the cookie is always
+  present on the first attempt.
+
 ### Added
 - Wired frontend unit tests and lint into CI (#649, M5): new `frontend-quality`
   job in `.github/workflows/ci.yml` runs `npm run lint` and

--- a/backend/src/test/java/com/example/buildnest_ecommerce/e2e/BaseApiTest.java
+++ b/backend/src/test/java/com/example/buildnest_ecommerce/e2e/BaseApiTest.java
@@ -63,13 +63,27 @@ public abstract class BaseApiTest {
         // token, so .cookie("XSRF-TOKEN") on that response finds nothing new. Clearing
         // the static spec first forces a clean request and a genuinely fresh cookie.
         RestAssured.requestSpecification = null;
-        String csrfToken = RestAssured.given()
-                .when()
-                .get("/api/auth/csrf")
-                .then()
-                .statusCode(204)
-                .extract()
-                .cookie("XSRF-TOKEN");
+
+        // Spring Security's CookieCsrfTokenRepository writes the Set-Cookie header via the
+        // deferred-token mechanism at the point csrfToken.getToken() resolves inside the
+        // controller — under CI's own scheduling this occasionally loses the race against the
+        // response being committed, and the very first request in a fresh JVM comes back with
+        // no XSRF-TOKEN cookie (#641). Not a logic bug: a bounded retry against the same
+        // idempotent GET reflects the eventual-consistency reality rather than masking it.
+        String csrfToken = null;
+        for (int attempt = 0; attempt < 3 && csrfToken == null; attempt++) {
+            csrfToken = RestAssured.given()
+                    .when()
+                    .get("/api/auth/csrf")
+                    .then()
+                    .statusCode(204)
+                    .extract()
+                    .cookie("XSRF-TOKEN");
+        }
+        if (csrfToken == null) {
+            throw new IllegalStateException(
+                    "XSRF-TOKEN cookie was not set by GET /api/auth/csrf after 3 attempts");
+        }
 
         RestAssured.requestSpecification = new io.restassured.builder.RequestSpecBuilder()
                 .addCookie("XSRF-TOKEN", csrfToken)


### PR DESCRIPTION
## Summary
- `BaseApiTest.setup()` (added by #640) extracted the `XSRF-TOKEN` cookie from `GET /api/auth/csrf` unconditionally, then passed it into RestAssured's `addHeader()` — a null cookie throws `IllegalArgumentException: Header value cannot be null`.
- This is what auto-filed #641 (a CI-failure bot issue against PR #640's own merge-preview run).
- Root-caused as a one-off timing race, not a deterministic regression: not reproducible locally across 2 full e2e runs (AuthApiTest/UserApiTest/CartApiTest together), and `master`'s `Quality Gate Pipeline` has been green on all 5 runs since #640 merged. Spring Security's `CookieCsrfTokenRepository` writes the `Set-Cookie` header via deferred-token resolution at the point `csrfToken.getToken()` is called in the controller — under CI's own scheduling this can occasionally lose the race against the response being committed.
- Fix: `setup()` now retries the bootstrap `GET /api/auth/csrf` up to 3 times before failing loudly with a clear `IllegalStateException`, reflecting the real eventual-consistency behavior rather than assuming first-attempt success.

Closes #641

## Test plan
- [x] `mvn test -P e2e-tests -Dtest=AuthApiTest,UserApiTest,CartApiTest` — all 3 classes pass (AuthApiTest 2/2, UserApiTest 1/1, CartApiTest 1/1), 0 failures/errors
- [x] CI (Quality Gate Pipeline) on this PR