### PR TITLE
docs: extract sibling-precedent's 8 edge cases into the KB article

### DIFF
--- a/docs/knowledge-base/project/README.md
+++ b/docs/knowledge-base/project/README.md
@@ -237,6 +237,21 @@ actually already brought up to the same standard — this exact gap surfaced twi
 pattern applied there too). When applying this pattern once, it's worth a quick scan of sibling
 docs (other rule files, other tables) for the same shape before considering the job done.
 
+**A completed extraction doesn't stop the source location from re-growing.** The pointer sentence
+left behind in step 2 above only replaces what existed *at extraction time* — nothing prevents a
+later session from appending new content to the same topic back at the source instead of adding
+it to the already-linked article, especially when each addition (a new edge case, a new "distinct
+from all previous" scenario) looks small in isolation. Confirmed empirically on
+`development-workflow.md` step 8's Notes cell (Amendment #49-51 extracted it once; by the time it
+was next measured, 8 more cases had been appended inline over ~8 issues, growing the cell to
+9,249 characters — larger than the 7,362-character KB article it still linked to the whole time).
+**When adding new content to a topic that already has a linked KB article, add it to the article,
+not back into the source location** — the existence of the link is itself the signal that this
+topic's home is the article now. When auditing a doc for bloat, specifically check whether any
+section linking to an external article has grown larger than the article it links to; that
+size inversion is a reliable sign of exactly this failure mode, cheaper to check than re-reading
+every section for duplicated content from scratch.
+
 See [Content Extraction: DRY/SSOT as the Decision Principle, Not Size](content-extraction-dry-ssot-as-the-decision-principle.md)
 for the underlying *why* behind the qualitative trigger above — DRY/SSOT and Separation of
 Concerns are the actual decision principles; abstraction, progressive disclosure, indirection,

--- a/docs/knowledge-base/project/sibling-precedent-consistency-check-for-repeated-decision-classes.md
+++ b/docs/knowledge-base/project/sibling-precedent-consistency-check-for-repeated-decision-classes.md
@@ -6,8 +6,8 @@ keywords: [sibling precedent, decision class, AskUserQuestion, epic sub-issues, 
 objective: "Before making a real architectural decision, how do I check whether this same *kind* of decision has already been made elsewhere in the repo — even if the two issues were never formally linked?"
 audience: "Anyone about to make a real architectural/placement decision on a GitHub issue in this repo — which mechanism to use, where to wire a new check, which of several viable designs to pick."
 scope: BuildNest-specific mechanics (GitHub issue/PR search), general principle (decision-class precedent matching)
-source_conversations: ["#320", "#358", "#359"]
-last_updated: 2026-07-16
+source_conversations: ["#320", "#358", "#359", "#441", "#489", "#559", "#130", "#652", "#630", "#650", "#558"]
+last_updated: 2026-08-02
 confidence: high
 evidence_strength: strong
 related_articles: [recurrence-escalation-for-process-and-amendment-mechanisms.md]
@@ -74,6 +74,87 @@ currently mandatory for every `solution-options-adr` step.
   for a new static-analysis tool," "extend an existing workflow vs. add a dedicated one," "which of
   several viable non-root/security-hardening approaches" — even if no formal epic or shared label
   connects the current issue to a prior one.
+
+## Documented Edge Cases
+
+The base check ("search for a prior instance of the same decision class, match its process
+unless there's a stated reason not to") has accumulated eight documented edge cases, each
+surfaced by a real issue where the base check's plain wording didn't obviously cover the
+situation encountered. Numbered first-through-eighth in discovery order; `development-workflow.md`
+step 8 (`solution-options-adr`)'s own Notes cell keeps only a one-line pointer to this section —
+this is the operative content when applying the check.
+
+**First case — a single, unambiguous precedent file to mirror.** E.g. building `ComponentB.tsx`
+by directly reading and matching an already-completed sibling `ComponentA.tsx` line-for-line, with
+no competing design to weigh. Reading that precedent file directly satisfies the check — a
+`gh search`-and-paste-output pass is not required on top of it.
+
+**Second case — no single clear precedent, or only a partial/by-analogy match.** Fall back to the
+`gh search` route (`gh issue list --search`, `gh pr list --search`) whenever the first case doesn't
+apply — that's when the self-determination "no real decision needed" judgment call actually needs
+external verification instead of being taken on faith.
+
+**Third case, distinct from both** (confirmed on #441): *multiple* partial/non-matching candidates
+exist (none a clean 1:1 mirror), and the agent judges "no real decision needed" without running a
+search. Defaulting this to "no search needed" on the first case's reasoning would be an unstated
+extension of that allowance — treat it the same as the second case: run the `gh search` route
+before concluding no decision is needed.
+
+**Fourth case, distinct from all three** (confirmed on #489): the issue contains **no decision
+class at all** — no competing design, no UI-placement choice, no prior-art question, nothing this
+check is built to compare against (e.g. a pure investigation-and-numeric-correction issue). No
+`gh search` is required (there is nothing to search for), but the check must still be explicitly
+stated as N/A with the reason ("no decision class present") in the visible response — silently
+skipping the step because "obviously nothing to decide" is indistinguishable, on a later audit,
+from having forgotten to check it at all.
+
+**Fifth case, distinct from all four** (confirmed on #559): *multiple* sibling files exist (not
+just one), and reading all of them directly shows they all mutually agree on the same pattern — no
+partial/non-matching divergence between them. Treat mutually-consistent multiple siblings the same
+as the first case: reading all of them directly satisfies the check, no `gh search` required — the
+consistency across siblings is itself the confirmation a `gh search` would otherwise establish.
+
+**Sixth case, distinct from all five** (confirmed on #130): a real decision class only *emerges*
+mid-task — the Proactive Recurrence Scan's own disposition of this check (made before the decision
+existed) correctly said N/A at the time, but nothing re-triggers the check once the decision
+actually surfaces later in the same session. The moment a genuine decision-class question emerges
+mid-task (even if resolved correctly via `AskUserQuestion`), seed this check as its own explicit
+`TaskCreate` item at that point — don't let a stale, pre-decision N/A stand uncorrected. This
+explicitly includes a Mid-Implementation Scope Discovery SAME-vs-SEPARATE classification
+(`development-workflow.md`'s own decision tree) — confirmed missed on #652 (two such calls made
+inline, neither seeded as its own `TaskCreate` item, since the "architectural/precedent decision"
+framing wasn't read as covering a scope classification). A SAME/SEPARATE call is a real
+decision-class question in the sense this case already means; don't require it to also resemble a
+design/tooling choice before it counts.
+
+**Seventh case, distinct from all six** (confirmed on #630): a real precedent existed and *was*
+found and correctly followed, but only incidentally — via an ordinary code-read while implementing
+(e.g. grepping for how a sibling test class seeds its own data and mirroring it), not through a
+deliberate "let me check for a sibling pattern" step. This satisfies the check in substance the
+same way the first case does, but never gets classified as such at the time, leaving a later audit
+unable to credit the process for it. When a precedent is found this way, name it explicitly as
+satisfying this check in the same task-list item/commit message that uses it (e.g. "mirrors `X`'s
+existing pattern, found via grep") — the citation itself is the artifact, no separate search step
+required on top of it.
+
+**Eighth case, distinct from all seven** (confirmed on #650): the "precedent" isn't a sibling
+GitHub issue or file at all — it's a wiki lesson (`docs/wiki/learned-lessons/`) whose full body
+already states the correct answer to the exact decision being made (not just a related gotcha).
+This is a distinct precedent *source* from the other seven cases, which all frame precedent as
+repo-history/sibling-file search — and it carries the same rigor requirement as any of them:
+reading the wiki-lessons Index grep's one-line description and confirming topical relevance is
+**not** sufficient; the full lesson file must actually be opened and its stated fix content
+applied, not just cited as "found." On #650, the matched lesson's body stated the correct fix
+verbatim across 3 separate re-greps, but only the index description was ever read — the wrong
+assumption was caught only by a live test failure, not by this check. See `work-on-issue.md`'s
+`[defect-class: wiki-second-leg-not-regrepped]` paragraph for the matching seeding-side fix.
+
+**A related but distinct risk — SonarCloud duplication** (confirmed on #558): mirroring a sibling
+closely (per the first or fifth case above) can itself trip SonarCloud's new-code duplication
+gate. If the mirrored file's control-flow blocks end up byte-for-byte identical to the precedent's
+(not just similarly shaped), extract the shared logic into a small utility rather than copy-pasting
+it — see [Sibling-Precedent Mirroring Can Trip SonarCloud's New-Code Duplication
+Gate](../../wiki/learned-lessons/sibling-precedent-mirroring-can-trip-sonarcloud-new-code-duplication-gate.md).
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- `development-workflow.md` step 8 (`solution-options-adr`)'s Notes cell had grown to 9,249 chars (~10% of the whole file) via case-accretion — a new numbered edge case appended inline every time an issue surfaced one (#441, #489, #559, #130, #652, #630, #650, plus the #558 SonarCloud-duplication note), despite already linking to a dedicated KB article for this exact check.
- Moved all 8 cases plus the SonarCloud-duplication note into a new "Documented Edge Cases" section in the KB article, which is now the larger, authoritative source (7,362 → 13,768 chars).
- The corresponding `development-workflow.md` compression (9,249 → 3,289 chars) is a local-only, gitignored edit and is not part of this PR.
- Verified: all 32 Sequence-table rows intact, both the KB-article link and the new intra-KB wiki-lesson link resolve to real files.

## Test plan
- [x] N/A — pure documentation change, no code/config affected