### PR TITLE
docs: correct stale M5 issue-count in README (self-correction, #124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ added for this workflow) before the first deploy.
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
 | M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 209/238 issues closed |
-| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 75/115 issues closed |
+| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 76/116 issues closed |
 
 ---
 


### PR DESCRIPTION
## Summary
- Self-correction: #124's own PR (#678) closed against M5 but never updated README's M5 issue-count row, which was already stale from prior closures too. Recomputed directly from the milestone API: 76/116 (was 75/115).

This is a documentation-only aggregate-fact fix, no code change.