### PR TITLE
docs: correct README M4 issue count (self-correction, #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ added for this workflow) before the first deploy.
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 211/238 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 212/238 issues closed |
 | M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 81/123 issues closed |
 
 ---


### PR DESCRIPTION
Self-correction: README's M4 milestone row was stale at 211/238 issues closed. #91's merge/close brings the real count to 212/238.

Not a code change — no test plan applicable beyond the numeric fact itself, verified via \`gh issue list --milestone "M4 — Feature Development" --state closed\`.