### PR TITLE
docs: log #108 occurrence, trim work-on-issue.md step-5 paragraph under 3KB

### DIFF
--- a/docs/knowledge-base/project/work-on-issue-operative-instruction-occurrence-history.md
+++ b/docs/knowledge-base/project/work-on-issue-operative-instruction-occurrence-history.md
@@ -359,6 +359,13 @@ independently-scoped follow-up).
   23 conditionally requires it whenever step 8 produces a new ADR — #561 did produce one, and the
   ADR index was only updated by judgment call, not instruction. → Added the `TaskCreate`-seeding
   requirement for the backfill check, and a 7th checklist line (`ADR index: <updated|N/A>`).
+- **#108** — 2nd occurrence of `[defect-class: requirement-traceability-backfill-not-seeded]`, a
+  literal-format sub-failure rather than a substance failure: OBS-02 was correctly added to SRS
+  §3.8.9/RTM §7.10, cited throughout the update-docs narrative, but the standalone "Step-7
+  traceability: cites `<FR-ID>`" line itself was never produced as its own independently-checkable
+  artifact. Confirmed the existing literal-format requirement already covers this shape; no
+  further wording change needed, logged here as the 2nd occurrence for future tier-escalation
+  reference.
 
 ## Follow-ups closure step
 


### PR DESCRIPTION
## Summary
- Adds #108 to the KB article as the 2nd occurrence of `[defect-class: requirement-traceability-backfill-not-seeded]` (a literal-format sub-failure — OBS-02 was correctly added to SRS/RTM but the standalone "Step-7 traceability:" line was never produced).
- Corresponding trim of `work-on-issue.md`'s step-5 paragraph (removed the now-extracted #108 citation, replaced with a pointer) — that file lives under gitignored `.claude/commands/`, not part of this PR, applied locally.
- Closes out task #14 from the #113 `/critique-prompt` session: the paragraph was the largest in the file (3,106 bytes) and approaching the ~3KB proactive-extraction threshold; now 2,959 bytes.

## Test plan
- [x] Docs-only change, no code touched