### PR TITLE
docs: self-correction — README M5 count post-#126 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ added for this workflow) before the first deploy.
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
 | M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 212/239 issues closed |
-| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 83/125 issues closed |
+| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 84/126 issues closed |
 
 ---
 


### PR DESCRIPTION
## Summary
- Self-correction, deferred aggregate-fact update per #126's own closure-time re-verification step: README's M5 milestone count was 83/125 (stale — computed before #126 merged and #708 was filed, both of which changed the real total/closed counts).
- Verified via \`gh issue list --milestone "M5 — Production Readiness" --state all\`: real current count is 84/126.

## Test plan
- [x] Docs-only, single-line numeric correction, verified against live `gh issue list` output