### PR TITLE
docs: sync README M4/M5 roadmap issue counts (#129 self-correction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,8 @@ added for this workflow) before the first deploy.
 | M1 — Stabilisation | Critical test defect fixes | 2026-07-04 | **Complete** (v0.2.0) — 16/16 issues |
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
-| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 212/239 issues closed |
-| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 84/126 issues closed |
+| M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 213/239 issues closed |
+| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 86/127 issues closed |
 
 ---
 


### PR DESCRIPTION
## Summary
- Self-correction PR: #129's own closure deferred the README aggregate M4/M5 issue-count update since the real post-merge count wasn't yet knowable at commit time.
- M4: 212→213, M5: 84/126→86/127 (partly reflecting #716, filed as a follow-up during #129's own work).

## Test plan
- [x] Doc-only change, no code touched