### PR TITLE
docs: sync README M5 issue count (#131 self-correction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ added for this workflow) before the first deploy.
 | M2 — Quality Foundation | Test coverage, OWASP, env docs | 2026-07-18 | **Complete** (v0.3.0) — 17/17 issues |
 | M3 — Technical Debt Reduction | ES upgrade, CSP hardening, circuit breaker fallbacks, coverage gate ratchet, CheckStyle debt reduction | 2026-08-01 | **In progress** — 15/41 issues closed |
 | M4 — Feature Development | Core commerce features + bug fixes | 2026-10-24 | **In progress** — 213/239 issues closed |
-| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 86/127 issues closed |
+| M5 — Production Readiness | Security hardening, deployment, observability, compliance | 2026-11-21 | **In progress** — 87/128 issues closed |
 
 ---
 


### PR DESCRIPTION
## Summary
- README's M5 roadmap row stated "86/127 issues closed", stale as of #131's own closure and #720's filing (both landed after that count was last written).
- Recomputed via `gh issue list --milestone "M5 — Production Readiness" --state closed/all --limit 500`: real values are 87/128.

Self-correction per #131's own deferred-aggregate-fact closure step.