### PR TITLE
fix: revert gatling-charts-highcharts 3.15.1->3.10.3 (#131 self-correction)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -350,7 +350,7 @@
 		<dependency>
 			<groupId>io.gatling.highcharts</groupId>
 			<artifactId>gatling-charts-highcharts</artifactId>
-			<version>3.15.1</version>
+			<version>3.10.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
## Summary
- #131's Maven dependency bumps included `gatling-charts-highcharts` 3.10.3 → 3.15.1 (a "minor" version bump per `versions:use-latest-releases -DallowMajorUpdates=false`, since it stays within major version 3).
- Master's post-merge `Full Test Matrix & Docker Publish` workflow caught a real regression: `Load Tests` failed with `NoClassDefFoundError: io/netty/channel/IoHandle` — Gatling 3.15.1 requires Netty 4.2+, incompatible with this repo's pinned `netty.version=4.1.136.Final` in `backend/pom.xml`.
- This is exactly the kind of "dependency:tree can look clean while a real build still fails" risk this repo's own wiki lesson (`maven-dependency-bumps-can-introduce-surprise-transitive-changes.md`) warns about — 1968 unit/integration tests + OWASP all passed on the original PR since none of them exercise the Gatling plugin's own classpath, only the `Full Test Matrix` workflow's dedicated `Load Tests` job does.

## Root cause & fix
Reverted `gatling-charts-highcharts` back to 3.10.3 (its pre-#131 version). Verified locally: `./mvnw gatling:test` no longer crashes on class loading after the revert.

## Classification
Per `verify-post-merge`'s outcome taxonomy: this is a genuine `confirmed-with-new-findings` post-merge outcome — the pre-merge PR checks did not exercise this path, and this fix addresses a real regression #131 introduced, not a pre-existing/unrelated failure.

Related: #131